### PR TITLE
Add Bootstrap styling for login/register

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,10 +5,21 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-VmM3DkLaQA2I5IwN6ULv2afF35p3xNmPR9U1FVLtZL1NVr7DiJ9N6byj1Ns26JXr"
+      crossorigin="anonymous"
+    />
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-WpOoh79alIwXD1R6rG8M1CIOhPMBVXsfS5aXoaZySUdkGFUTkOcJCIZtB4hXe9xo"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -36,13 +36,43 @@ export default function Login() {
   }, []);
 
   return (
-    <form onSubmit={handleLogin}>
-      <h2>Iniciar Sesión</h2>
-      <input type="email" placeholder="Email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
-      <input type="password" placeholder="Contraseña" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
-      <button type="submit">Entrar</button>
-      <button type="button" onClick={() => navigate('/register')}>Registrarse</button>
-      <div id="googleBtn" style={{ marginTop: '1rem' }}></div>
-    </form>
+    <div className="container mt-5">
+      <div className="row justify-content-center">
+        <div className="col-md-6 col-lg-4">
+          <form onSubmit={handleLogin} className="p-4 border rounded bg-light">
+            <h2 className="mb-4 text-center">Iniciar Sesión</h2>
+            <div className="mb-3">
+              <input
+                type="email"
+                className="form-control"
+                placeholder="Email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                type="password"
+                className="form-control"
+                placeholder="Contraseña"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+              />
+            </div>
+            <button type="submit" className="btn btn-primary w-100 mb-2">
+              Entrar
+            </button>
+            <button
+              type="button"
+              className="btn btn-link w-100"
+              onClick={() => navigate('/register')}
+            >
+              Registrarse
+            </button>
+            <div id="googleBtn" className="d-flex justify-content-center mt-3"></div>
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -21,14 +21,61 @@ export default function Register() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h2>Registro</h2>
-      <input placeholder="Nombre" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
-      <input type="email" placeholder="Email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
-      <input type="password" placeholder="Contraseña" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
-      <input type="password" placeholder="Confirmar contraseña" value={form.confirmPassword} onChange={e => setForm({ ...form, confirmPassword: e.target.value })} />
-      <button type="submit">Registrarse</button>
-      <button type="button" onClick={() => navigate('/login')}>Ya tienes cuenta</button>
-    </form>
+    <div className="container mt-5">
+      <div className="row justify-content-center">
+        <div className="col-md-6 col-lg-4">
+          <form onSubmit={handleSubmit} className="p-4 border rounded bg-light">
+            <h2 className="mb-4 text-center">Registro</h2>
+            <div className="mb-3">
+              <input
+                className="form-control"
+                placeholder="Nombre"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                type="email"
+                className="form-control"
+                placeholder="Email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                type="password"
+                className="form-control"
+                placeholder="Contraseña"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                type="password"
+                className="form-control"
+                placeholder="Confirmar contraseña"
+                value={form.confirmPassword}
+                onChange={(e) =>
+                  setForm({ ...form, confirmPassword: e.target.value })
+                }
+              />
+            </div>
+            <button type="submit" className="btn btn-primary w-100 mb-2">
+              Registrarse
+            </button>
+            <button
+              type="button"
+              className="btn btn-link w-100"
+              onClick={() => navigate('/login')}
+            >
+              Ya tienes cuenta
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- include Bootstrap via CDN in `index.html`
- style Login and Register pages using Bootstrap classes for a responsive layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881773252a48320b2109df38b9549e2