### PR TITLE
Add roles and admin code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# E-commers
+
+Este proyecto contiene un backend en Express y un frontend en React. Para iniciar el backend asegúrate de crear un archivo `.env` con las siguientes variables:
+
+```
+MONGO_URI=<cadena de conexión a MongoDB>
+JWT_SECRET=<secreto para JWT>
+EMAIL_USER=<usuario de correo para enviar verificaciones>
+EMAIL_PASS=<contraseña del correo>
+BASE_URL=<url pública del frontend>
+ADMIN_CODE=<código especial para crear administradores>
+```
+
+Si al registrarse se proporciona un código que coincida con `ADMIN_CODE`, el usuario será creado con el rol de administrador.
+

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -1,15 +1,16 @@
-import mongoose from "mongoose";
+import mongoose from 'mongoose';
 
 const productSchema = new mongoose.Schema({
-    name: { type: String, required: true},
-   descripcion: String,
-   price: {type: Number, required: true},
-   image: String,
-   category: String,
-   inStock: {type: Boolean, default: true },
+  name: { type: String, required: true },
+  description: String,
+  price: { type: Number, required: true },
+  image: String,
+  category: String,
+  inStock: { type: Boolean, default: true },
 }, {
-    timestamps: true,
-}); 
+  timestamps: true,
+});
 
 const Product = mongoose.model('Product', productSchema);
+
 export default Product;

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -11,6 +11,11 @@ const userSchema = new mongoose.Schema({
     lowercase: true
   },
   password: { type: String, required: true },
+  role: {
+    type: String,
+    enum: ['cliente', 'admin'],
+    default: 'cliente'
+  },
   verified: { type: Boolean, default: false },
 }, {
   timestamps: true,

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -16,7 +16,7 @@ const generateToken = (id) => {
 
 // Registro de usuario
 router.post('/register', async (req, res) => {
-  const { name, email, password, confirmPassword } = req.body;
+  const { name, email, password, confirmPassword, adminCode } = req.body;
   try {
     const exists = await User.findOne({ email });
     if (exists) return res.status(400).json({ message: 'El usuario ya existe' });
@@ -25,7 +25,8 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ message: 'Las contrase\u00f1as no coinciden' });
     }
 
-    const user = await User.create({ name, email, password });
+    const role = adminCode && adminCode === process.env.ADMIN_CODE ? 'admin' : 'cliente';
+    const user = await User.create({ name, email, password, role });
 
     const verifyToken = generateToken(user._id);
     const url = `${process.env.BASE_URL}/api/users/verify/${verifyToken}`;
@@ -79,6 +80,7 @@ router.post('/login', async (req, res) => {
         _id: user._id,
         name: user.name,
         email: user.email,
+        role: user.role,
         token: generateToken(user._id),
       });
     } else {
@@ -108,6 +110,7 @@ router.post('/google-login', async (req, res) => {
       _id: user._id,
       name: user.name,
       email: user.email,
+      role: user.role,
       token: generateToken(user._id),
     });
   } catch (err) {

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -1,29 +1,29 @@
 import express from 'express';
-import Product from '../models/Product';
+import Product from '../models/Product.js';
 
 const router = express.Router();
 
-// Obtener todos los producctos
-router.get('/', async (requestAnimationFrame, res) => {
-    try{
-        const products = await Product.find();
-        res.json(products);
-    } catch (err){
-        res.status(500).json({ message: err.message })
-    }
+// Obtener todos los productos
+router.get('/', async (req, res) => {
+  try {
+    const products = await Product.find();
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
 });
 
 // Crear un nuevo producto
 router.post('/', async (req, res) => {
-    const { name, description, price, image, category, inStock} = req.body;
-    const product = new Product({ name, description, price, image, category, inStock });
+  const { name, description, price, image, category, inStock } = req.body;
+  const product = new Product({ name, description, price, image, category, inStock });
 
-    try {
-        const newProduct = await product.save();
-        res.status(201).json(newProduct);
-    } catch {
-        res.status(400).json({ message: err.message});
-    }
+  try {
+    const newProduct = await product.save();
+    res.status(201).json(newProduct);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
 });
 
 export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import authRoutes from './routes/authRoutes.js';
+import productRoutes from './routes/productRoutes.js';
 
 
 
@@ -24,6 +25,7 @@ mongoose.connect(process.env.MONGO_URI, {
   .catch(err => console.error(err));
 
   app.use('/api/users', authRoutes);
+  app.use('/api/products', productRoutes);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,7 @@ export default function Login() {
     try {
       const res = await axios.post('http://localhost:5000/api/users/login', form);
       localStorage.setItem('token', res.data.token);
+      localStorage.setItem('role', res.data.role);
       alert('Login exitoso');
     } catch (err) {
       alert(err.response.data.message || 'Error al iniciar sesión');
@@ -25,6 +26,7 @@ export default function Login() {
           try {
             const res = await axios.post('http://localhost:5000/api/users/google-login', { token: response.credential });
             localStorage.setItem('token', res.data.token);
+            localStorage.setItem('role', res.data.role);
             alert('Login exitoso');
           } catch (err) {
             alert(err.response?.data?.message || 'Error al iniciar sesi\u00f3n');

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 export default function Register() {
-  const [form, setForm] = useState({ name: '', email: '', password: '', confirmPassword: '' });
+  const [form, setForm] = useState({ name: '', email: '', password: '', confirmPassword: '', adminCode: '' });
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -61,6 +61,14 @@ export default function Register() {
                 onChange={(e) =>
                   setForm({ ...form, confirmPassword: e.target.value })
                 }
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                className="form-control"
+                placeholder="Código de administrador (opcional)"
+                value={form.adminCode}
+                onChange={(e) => setForm({ ...form, adminCode: e.target.value })}
               />
             </div>
             <button type="submit" className="btn btn-primary w-100 mb-2">


### PR DESCRIPTION
## Summary
- add admin code environment variable instructions
- add role field to user model
- support role selection during register via `adminCode`
- return role in login & Google login
- store role in localStorage in frontend
- allow product routes and fix product model

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68817cc1c8e0832098a94bef734f6ca5