### PR TITLE
Block login until email verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ ADMIN_CODE=<código especial para crear administradores>
 
 Si al registrarse se proporciona un código que coincida con `ADMIN_CODE`, el usuario será creado con el rol de administrador.
 
+Tras registrarte recibirás un correo con un enlace para verificar tu cuenta. Hasta que no confirmes tu email no podrás iniciar sesión.
+


### PR DESCRIPTION
## Summary
- require users to confirm their email before logging in
- automatically mark accounts as verified when signing in with Google
- document email verification requirement

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688181c2d2d883208a2c389cb631e3f6