### PR TITLE
Add home page and redirect after login

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,11 +2,13 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Register from './pages/Register.jsx';
 import Login from './pages/Login.jsx';
 import Profile from './pages/Profile.jsx';
+import Home from './pages/Home.jsx';
 
 export default function App() {
   return (
     <Router>
       <Routes>
+        <Route path="/" element={<Home />} />
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<Login />} />
         <Route path="/profile" element={<Profile />} />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div className="container mt-5">
+      <h1 className="mb-4 text-center">Bienvenido</h1>
+      <p className="lead text-center">
+        Aquí se mostrarán ofertas, promociones y productos destacados.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,6 +13,7 @@ export default function Login() {
       localStorage.setItem('token', res.data.token);
       localStorage.setItem('role', res.data.role);
       alert('Login exitoso');
+      navigate('/');
     } catch (err) {
       alert(err.response.data.message || 'Error al iniciar sesión');
     }
@@ -28,6 +29,7 @@ export default function Login() {
             localStorage.setItem('token', res.data.token);
             localStorage.setItem('role', res.data.role);
             alert('Login exitoso');
+            navigate('/');
           } catch (err) {
             alert(err.response?.data?.message || 'Error al iniciar sesi\u00f3n');
           }


### PR DESCRIPTION
## Summary
- create basic `Home.jsx` for the app landing page
- route `/` to new home component
- redirect to home after user login (regular and Google login)

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68818693c3e083209dff0cf3f4e8bfc6