### PR TITLE
Fix bootstrap CDN integrity

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-VmM3DkLaQA2I5IwN6ULv2afF35p3xNmPR9U1FVLtZL1NVr7DiJ9N6byj1Ns26JXr"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     />
     <script src="https://accounts.google.com/gsi/client" async defer></script>
@@ -18,7 +18,7 @@
     <script type="module" src="/src/main.jsx"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-WpOoh79alIwXD1R6rG8M1CIOhPMBVXsfS5aXoaZySUdkGFUTkOcJCIZtB4hXe9xo"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
       crossorigin="anonymous"
     ></script>
   </body>


### PR DESCRIPTION
## Summary
- update the SRI hashes for Bootstrap 5.3.3 in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68822b433e708320a2d78759e119a850