### PR TITLE
Enable user avatar management

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -16,6 +16,7 @@ const userSchema = new mongoose.Schema({
     enum: ['cliente', 'admin'],
     default: 'cliente'
   },
+  avatar: { type: String, default: '' },
   verified: { type: Boolean, default: false },
 }, {
   timestamps: true,

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,13 +4,13 @@ export default function Navbar() {
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
   const name = localStorage.getItem('name') || '';
-  const picture = localStorage.getItem('picture');
+  const avatar = localStorage.getItem('avatar');
 
   const handleLogout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('role');
     localStorage.removeItem('name');
-    localStorage.removeItem('picture');
+    localStorage.removeItem('avatar');
     navigate('/login');
   };
 
@@ -28,8 +28,8 @@ export default function Navbar() {
               className="rounded-circle overflow-hidden d-flex justify-content-center align-items-center me-2"
               style={{ width: '40px', height: '40px' }}
             >
-              {picture ? (
-                <img src={picture} alt="Usuario" className="w-100 h-100" />
+              {avatar ? (
+                <img src={avatar} alt="Usuario" className="w-100 h-100" />
               ) : (
                 <span className="fw-bold">{initial}</span>
               )}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,7 +13,7 @@ export default function Login() {
       localStorage.setItem('token', res.data.token);
       localStorage.setItem('role', res.data.role);
       localStorage.setItem('name', res.data.name);
-      localStorage.removeItem('picture');
+      localStorage.setItem('avatar', res.data.avatar || '');
       alert('Login exitoso');
       navigate('/');
     } catch (err) {
@@ -28,11 +28,12 @@ export default function Login() {
         callback: async (response) => {
           try {
             const decoded = JSON.parse(atob(response.credential.split('.')[1]));
-            localStorage.setItem('picture', decoded.picture);
+            localStorage.setItem('avatar', decoded.picture);
             const res = await axios.post('http://localhost:5000/api/users/google-login', { token: response.credential });
             localStorage.setItem('token', res.data.token);
             localStorage.setItem('role', res.data.role);
             localStorage.setItem('name', res.data.name);
+            localStorage.setItem('avatar', res.data.avatar || decoded.picture);
             alert('Login exitoso');
             navigate('/');
           } catch (err) {

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -3,21 +3,56 @@ import axios from 'axios';
 
 export default function Profile() {
   const [user, setUser] = useState(null);
+  const [avatar, setAvatar] = useState('');
+  const [message, setMessage] = useState('');
 
   useEffect(() => {
     const token = localStorage.getItem('token');
     axios.get('http://localhost:5000/api/users/profile', {
       headers: { Authorization: `Bearer ${token}` },
     })
-    .then(res => setUser(res.data))
-    .catch(err => alert('No autorizado'));
+      .then(res => {
+        setUser(res.data.user);
+        setAvatar(res.data.user.avatar || '');
+      })
+      .catch(() => alert('No autorizado'));
   }, []);
+
+  const handleUpdate = async () => {
+    const token = localStorage.getItem('token');
+    try {
+      await axios.put('http://localhost:5000/api/users/avatar', { avatar }, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      localStorage.setItem('avatar', avatar);
+      setMessage('Imagen actualizada');
+    } catch (err) {
+      setMessage('Error al actualizar');
+    }
+  };
 
   return (
     <div>
       <h2>Perfil</h2>
       {user ? (
-        <pre>{JSON.stringify(user, null, 2)}</pre>
+        <div>
+          <div className="mb-3">
+            {avatar && (
+              <img src={avatar} alt="Avatar" style={{ width: '100px', height: '100px' }} />
+            )}
+          </div>
+          <input
+            type="text"
+            className="form-control mb-2"
+            placeholder="URL de la imagen"
+            value={avatar}
+            onChange={(e) => setAvatar(e.target.value)}
+          />
+          <button className="btn btn-primary" onClick={handleUpdate}>
+            Actualizar
+          </button>
+          {message && <p className="mt-2">{message}</p>}
+        </div>
       ) : (
         <p>Cargando o no autorizado...</p>
       )}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 export default function Register() {
-  const [form, setForm] = useState({ name: '', email: '', password: '', confirmPassword: '', adminCode: '' });
+  const [form, setForm] = useState({ name: '', email: '', password: '', confirmPassword: '', adminCode: '', avatar: '' });
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -61,6 +61,14 @@ export default function Register() {
                 onChange={(e) =>
                   setForm({ ...form, confirmPassword: e.target.value })
                 }
+              />
+            </div>
+            <div className="mb-3">
+              <input
+                className="form-control"
+                placeholder="URL de avatar (opcional)"
+                value={form.avatar}
+                onChange={(e) => setForm({ ...form, avatar: e.target.value })}
               />
             </div>
             <div className="mb-3">


### PR DESCRIPTION
## Summary
- add avatar field to User model
- return avatar on login and google login
- allow avatar updates via new backend route
- support avatar in registration flow
- display avatar in Navbar and Profile pages
- allow avatar editing from Profile page

## Testing
- `npm test` *(fails: Missing script 'test' for frontend)*
- `npm test` *(fails: "Error: no test specified" for backend)*

------
https://chatgpt.com/codex/tasks/task_e_6882b0d87ff883209f1a3ceb0b4a36b7