### PR TITLE
Add avatar update on click

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,10 +1,14 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { useRef, useState } from 'react';
+import axios from 'axios';
 
 export default function Navbar() {
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
   const name = localStorage.getItem('name') || '';
-  const avatar = localStorage.getItem('avatar');
+  const storedAvatar = localStorage.getItem('avatar');
+  const [avatar, setAvatar] = useState(storedAvatar);
+  const fileInputRef = useRef(null);
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -12,6 +16,32 @@ export default function Navbar() {
     localStorage.removeItem('name');
     localStorage.removeItem('avatar');
     navigate('/login');
+  };
+
+  const handleAvatarClick = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      const base64 = reader.result;
+      setAvatar(base64);
+      localStorage.setItem('avatar', base64);
+      try {
+        const token = localStorage.getItem('token');
+        await axios.put('http://localhost:5000/api/users/avatar', { avatar: base64 }, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   const initial = name.charAt(0).toUpperCase();
@@ -26,13 +56,21 @@ export default function Navbar() {
           <div className="d-flex align-items-center">
             <div
               className="rounded-circle overflow-hidden d-flex justify-content-center align-items-center me-2"
-              style={{ width: '40px', height: '40px' }}
+              style={{ width: '40px', height: '40px', border: '1px solid black', cursor: 'pointer' }}
+              onClick={handleAvatarClick}
             >
               {avatar ? (
                 <img src={avatar} alt="Usuario" className="w-100 h-100" />
               ) : (
                 <span className="fw-bold">{initial}</span>
               )}
+              <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                className="d-none"
+              />
             </div>
             <button
               type="button"

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import axios from 'axios';
 
 export default function Profile() {
   const [user, setUser] = useState(null);
   const [avatar, setAvatar] = useState('');
   const [message, setMessage] = useState('');
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -31,6 +32,22 @@ export default function Profile() {
     }
   };
 
+  const handleImageClick = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setAvatar(reader.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
   return (
     <div>
       <h2>Perfil</h2>
@@ -38,8 +55,21 @@ export default function Profile() {
         <div>
           <div className="mb-3">
             {avatar && (
-              <img src={avatar} alt="Avatar" style={{ width: '100px', height: '100px' }} />
+              <div
+                className="rounded-circle overflow-hidden"
+                style={{ width: '100px', height: '100px', border: '1px solid black', cursor: 'pointer' }}
+                onClick={handleImageClick}
+              >
+                <img src={avatar} alt="Avatar" className="w-100 h-100" />
+              </div>
             )}
+            <input
+              type="file"
+              accept="image/*"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              className="d-none"
+            />
           </div>
           <input
             type="text"


### PR DESCRIPTION
## Summary
- add border and click handler to navbar avatar
- allow uploading new avatar from navbar
- enable avatar change by clicking image on profile page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6882c4a12a288320ae749331e54c761e