### PR TITLE
Fix avatar persistence on logout

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import axios from 'axios';
 
 export default function Navbar() {
@@ -10,11 +10,17 @@ export default function Navbar() {
   const [avatar, setAvatar] = useState(storedAvatar);
   const fileInputRef = useRef(null);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('avatar');
+    setAvatar(stored || '');
+  }, [token]);
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('role');
     localStorage.removeItem('name');
     localStorage.removeItem('avatar');
+    setAvatar('');
     navigate('/login');
   };
 


### PR DESCRIPTION
## Summary
- update Navbar to clear avatar state on logout
- reload avatar from localStorage when token changes

## Testing
- `npm run lint` *(fails: Cannot find package 'globals/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6882eb2221e8832092a478086bad75b0