### PR TITLE
Implement product management

### DIFF
--- a/backend/middleware/adminMiddleware.js
+++ b/backend/middleware/adminMiddleware.js
@@ -1,0 +1,7 @@
+export default function isAdmin(req, res, next) {
+  if (req.user && req.user.role === 'admin') {
+    next();
+  } else {
+    res.status(403).json({ message: 'Acceso solo para administradores' });
+  }
+}

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -4,7 +4,10 @@ const productSchema = new mongoose.Schema({
   name: { type: String, required: true },
   description: String,
   price: { type: Number, required: true },
-  image: String,
+  images: {
+    type: [String],
+    validate: [arr => arr.length <= 3, 'Máximo 3 imágenes']
+  },
   category: String,
   inStock: { type: Boolean, default: true },
 }, {

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import Product from '../models/Product.js';
+import protect from '../middleware/authMiddleware.js';
+import isAdmin from '../middleware/adminMiddleware.js';
 
 const router = express.Router();
 
@@ -13,10 +15,22 @@ router.get('/', async (req, res) => {
   }
 });
 
+// Obtener producto por ID
+router.get('/:id', async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Producto no encontrado' });
+    res.json(product);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 // Crear un nuevo producto
-router.post('/', async (req, res) => {
-  const { name, description, price, image, category, inStock } = req.body;
-  const product = new Product({ name, description, price, image, category, inStock });
+router.post('/', protect, isAdmin, async (req, res) => {
+  const { name, description, price, images = [], category, inStock } = req.body;
+  if (images.length > 3) return res.status(400).json({ message: 'Máximo 3 imágenes' });
+  const product = new Product({ name, description, price, images, category, inStock });
 
   try {
     const newProduct = await product.save();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import Register from './pages/Register.jsx';
 import Login from './pages/Login.jsx';
 import Profile from './pages/Profile.jsx';
 import Home from './pages/Home.jsx';
+import Products from './pages/Products.jsx';
+import ProductDetail from './pages/ProductDetail.jsx';
+import AddProduct from './pages/AddProduct.jsx';
 import Navbar from './components/Navbar.jsx';
 
 export default function App() {
@@ -14,6 +17,9 @@ export default function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<Login />} />
         <Route path="/profile" element={<Profile />} />
+        <Route path="/products" element={<Products />} />
+        <Route path="/products/:id" element={<ProductDetail />} />
+        <Route path="/add-product" element={<AddProduct />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 export default function Navbar() {
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
+  const role = localStorage.getItem('role');
   const name = localStorage.getItem('name') || '';
   const storedAvatar = localStorage.getItem('avatar');
   const [avatar, setAvatar] = useState(storedAvatar);
@@ -55,9 +56,15 @@ export default function Navbar() {
   return (
     <nav className="navbar navbar-light bg-light">
       <div className="container d-flex justify-content-between">
-        <Link className="navbar-brand" to="/">
-          Ana<strong>Roma</strong>
-        </Link>
+        <div className="d-flex align-items-center">
+          <Link className="navbar-brand me-3" to="/">
+            Ana<strong>Roma</strong>
+          </Link>
+          <Link className="me-3" to="/products">Productos</Link>
+          {role === 'admin' && (
+            <Link className="me-3" to="/add-product">Agregar producto</Link>
+          )}
+        </div>
         {token && (
           <div className="d-flex align-items-center">
             <div

--- a/frontend/src/pages/AddProduct.jsx
+++ b/frontend/src/pages/AddProduct.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+export default function AddProduct() {
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    price: '',
+    image1: '',
+    image2: '',
+    image3: '',
+    category: '',
+    inStock: true,
+  });
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    const images = [form.image1, form.image2, form.image3].filter(Boolean);
+    try {
+      await axios.post('http://localhost:5000/api/products', {
+        name: form.name,
+        description: form.description,
+        price: Number(form.price),
+        images,
+        category: form.category,
+        inStock: form.inStock,
+      }, { headers: { Authorization: `Bearer ${token}` } });
+      alert('Producto creado');
+      navigate('/products');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al crear');
+    }
+  };
+
+  return (
+    <div className="container mt-5">
+      <h2 className="mb-4">Agregar Producto</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <input className="form-control" placeholder="Título" value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <textarea className="form-control" placeholder="Descripción" value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <input type="number" className="form-control" placeholder="Precio" value={form.price}
+            onChange={(e) => setForm({ ...form, price: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <input className="form-control" placeholder="Imagen 1" value={form.image1}
+            onChange={(e) => setForm({ ...form, image1: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <input className="form-control" placeholder="Imagen 2" value={form.image2}
+            onChange={(e) => setForm({ ...form, image2: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <input className="form-control" placeholder="Imagen 3" value={form.image3}
+            onChange={(e) => setForm({ ...form, image3: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <input className="form-control" placeholder="Categoría" value={form.category}
+            onChange={(e) => setForm({ ...form, category: e.target.value })} />
+        </div>
+        <div className="form-check mb-3">
+          <input className="form-check-input" type="checkbox" checked={form.inStock}
+            onChange={(e) => setForm({ ...form, inStock: e.target.checked })} id="instock" />
+          <label className="form-check-label" htmlFor="instock">En stock</label>
+        </div>
+        <button type="submit" className="btn btn-primary">Guardar</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+
+export default function ProductDetail() {
+  const { id } = useParams();
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    axios.get(`http://localhost:5000/api/products/${id}`)
+      .then(res => setProduct(res.data))
+      .catch(() => alert('Error al cargar producto'));
+  }, [id]);
+
+  if (!product) return <div className="container mt-5">Cargando...</div>;
+
+  return (
+    <div className="container mt-5">
+      <h2>{product.name}</h2>
+      <p className="text-muted">${product.price}</p>
+      <p>{product.description}</p>
+      <div className="d-flex flex-wrap">
+        {product.images && product.images.map((img, idx) => (
+          <img key={idx} src={img} alt={product.name} className="me-2 mb-2" style={{maxWidth:'200px'}} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+export default function Products() {
+  const [products, setProducts] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/products')
+      .then(res => setProducts(res.data))
+      .catch(() => alert('Error al obtener productos'));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h2 className="mb-4">Productos</h2>
+      <div className="row">
+        {products.map(prod => (
+          <div className="col-md-4 mb-3" key={prod._id}>
+            <div className="card h-100" onClick={() => navigate(`/products/${prod._id}`)} style={{cursor:'pointer'}}>
+              {prod.images && prod.images[0] && (
+                <img src={prod.images[0]} className="card-img-top" alt={prod.name} />
+              )}
+              <div className="card-body">
+                <h5 className="card-title">{prod.name}</h5>
+                <p className="card-text">${prod.price}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow up to three images in products
- secure product creation with admin middleware
- expose route to fetch single products
- show products and product details in the frontend
- let admins create products from the UI
- update navigation links

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6882fb9224a083208fc8c875be6e319e