### PR TITLE
Add cart feature with carousel in product cards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,21 +6,26 @@ import Home from './pages/Home.jsx';
 import Products from './pages/Products.jsx';
 import ProductDetail from './pages/ProductDetail.jsx';
 import AddProduct from './pages/AddProduct.jsx';
+import Cart from './pages/Cart.jsx';
 import Navbar from './components/Navbar.jsx';
+import { CartProvider } from './context/CartContext.jsx';
 
 export default function App() {
   return (
-    <Router>
-      <Navbar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/products" element={<Products />} />
-        <Route path="/products/:id" element={<ProductDetail />} />
-        <Route path="/add-product" element={<AddProduct />} />
-      </Routes>
-    </Router>
+    <CartProvider>
+      <Router>
+        <Navbar />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/products" element={<Products />} />
+          <Route path="/products/:id" element={<ProductDetail />} />
+          <Route path="/add-product" element={<AddProduct />} />
+          <Route path="/cart" element={<Cart />} />
+        </Routes>
+      </Router>
+    </CartProvider>
   );
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -64,6 +64,7 @@ export default function Navbar() {
           {role === 'admin' && (
             <Link className="me-3" to="/add-product">Agregar producto</Link>
           )}
+          <Link className="me-3" to="/cart">Mi carrito</Link>
         </div>
         {token && (
           <div className="d-flex align-items-center">

--- a/frontend/src/context/CartContext.jsx
+++ b/frontend/src/context/CartContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useEffect, useState } from 'react';
+
+const CartContext = createContext();
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState(() => {
+    const stored = localStorage.getItem('cart');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(items));
+  }, [items]);
+
+  const addItem = (product) => {
+    setItems(prev => [...prev, product]);
+  };
+
+  const total = items.reduce((sum, item) => sum + item.price, 0);
+
+  return (
+    <CartContext.Provider value={{ items, addItem, total }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export default CartContext;

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import CartContext from '../context/CartContext.jsx';
+
+export default function Cart() {
+  const { items, total } = useContext(CartContext);
+
+  return (
+    <div className="container mt-4">
+      <h2 className="mb-4">Mi Carrito</h2>
+      {items.length === 0 ? (
+        <p>No hay productos en el carrito</p>
+      ) : (
+        <>
+          <ul className="list-group mb-3">
+            {items.map((item, idx) => (
+              <li key={idx} className="list-group-item d-flex justify-content-between align-items-center">
+                {item.name}
+                <span>${item.price}</span>
+              </li>
+            ))}
+          </ul>
+          <h4>Total: ${total}</h4>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import CartContext from '../context/CartContext.jsx';
 
 export default function Products() {
   const [products, setProducts] = useState([]);
   const navigate = useNavigate();
+  const { addItem } = useContext(CartContext);
 
   useEffect(() => {
     axios.get('http://localhost:5000/api/products')
@@ -18,13 +20,43 @@ export default function Products() {
       <div className="row">
         {products.map(prod => (
           <div className="col-md-4 mb-3" key={prod._id}>
-            <div className="card h-100" onClick={() => navigate(`/products/${prod._id}`)} style={{cursor:'pointer'}}>
-              {prod.images && prod.images[0] && (
-                <img src={prod.images[0]} className="card-img-top" alt={prod.name} />
+            <div className="card h-100" style={{ cursor: 'pointer' }} onClick={() => navigate(`/products/${prod._id}`)}>
+              {prod.images && prod.images.length > 0 && (
+                <div id={`carousel-${prod._id}`} className="carousel slide">
+                  <div className="carousel-inner">
+                    {prod.images.map((img, idx) => (
+                      <div key={idx} className={`carousel-item ${idx === 0 ? 'active' : ''}`}> 
+                        <img src={img} className="d-block w-100" alt={prod.name} />
+                      </div>
+                    ))}
+                  </div>
+                  {prod.images.length > 1 && (
+                    <>
+                      <button className="carousel-control-prev" type="button" data-bs-target={`#carousel-${prod._id}`} data-bs-slide="prev" onClick={e => e.stopPropagation()}>
+                        <span className="carousel-control-prev-icon" aria-hidden="true"></span>
+                        <span className="visually-hidden">Previous</span>
+                      </button>
+                      <button className="carousel-control-next" type="button" data-bs-target={`#carousel-${prod._id}`} data-bs-slide="next" onClick={e => e.stopPropagation()}>
+                        <span className="carousel-control-next-icon" aria-hidden="true"></span>
+                        <span className="visually-hidden">Next</span>
+                      </button>
+                    </>
+                  )}
+                </div>
               )}
               <div className="card-body">
                 <h5 className="card-title">{prod.name}</h5>
                 <p className="card-text">${prod.price}</p>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={e => {
+                    e.stopPropagation();
+                    addItem(prod);
+                  }}
+                >
+                  Agregar al carrito
+                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- implement `CartContext` to store items and track total
- add a new `Cart` page with the cart total
- show product images in a Bootstrap carousel and add "Agregar al carrito" button
- wire up routes and navbar link for the cart

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883029edec88320ae5837aae2d0ed7e