### PR TITLE
Add admin product editing

### DIFF
--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -58,4 +58,52 @@ router.patch('/:id/stock', async (req, res) => {
   }
 });
 
+// Actualizar un producto
+router.put('/:id', protect, isAdmin, async (req, res) => {
+  const { name, description, price, images = [], category, inStock, stock } = req.body;
+  if (images.length > 3) return res.status(400).json({ message: 'Máximo 3 imágenes' });
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Producto no encontrado' });
+    product.name = name;
+    product.description = description;
+    product.price = price;
+    product.images = images;
+    product.category = category;
+    product.inStock = inStock;
+    if (stock !== undefined) product.stock = stock;
+    const updated = await product.save();
+    res.json(updated);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Establecer el stock de un producto
+router.put('/:id/stock', protect, isAdmin, async (req, res) => {
+  const { stock } = req.body;
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Producto no encontrado' });
+    if (stock < 0) return res.status(400).json({ message: 'El stock no puede ser negativo' });
+    product.stock = stock;
+    const updated = await product.save();
+    res.json(updated);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Eliminar un producto
+router.delete('/:id', protect, isAdmin, async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Producto no encontrado' });
+    await product.deleteOne();
+    res.json({ message: 'Producto eliminado' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 export default router;

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -6,8 +6,23 @@ import CartContext from '../context/CartContext.jsx';
 export default function Products() {
   const [products, setProducts] = useState([]);
   const [quantities, setQuantities] = useState({});
+  const [editProduct, setEditProduct] = useState(null);
+  const [editForm, setEditForm] = useState({
+    name: '',
+    description: '',
+    price: '',
+    image1: '',
+    image2: '',
+    image3: '',
+    category: '',
+    inStock: true,
+    stock: 0,
+  });
+  const [stockProduct, setStockProduct] = useState(null);
+  const [newStock, setNewStock] = useState(0);
   const navigate = useNavigate();
   const { addItem } = useContext(CartContext);
+  const role = localStorage.getItem('role');
 
   useEffect(() => {
     axios.get('http://localhost:5000/api/products')
@@ -25,6 +40,79 @@ export default function Products() {
     await addItem(prod, qty);
     setProducts(prev => prev.map(p => p._id === prod._id ? { ...p, stock: p.stock - qty } : p));
     setQuantities(q => ({ ...q, [prod._id]: 1 }));
+  };
+
+  const handleEditClick = (prod) => {
+    const [img1 = '', img2 = '', img3 = ''] = prod.images || [];
+    setEditForm({
+      name: prod.name,
+      description: prod.description || '',
+      price: prod.price,
+      image1: img1,
+      image2: img2,
+      image3: img3,
+      category: prod.category || '',
+      inStock: prod.inStock,
+      stock: prod.stock || 0,
+    });
+    setEditProduct(prod);
+  };
+
+  const handleEditSubmit = async (e) => {
+    e.preventDefault();
+    if (!editProduct) return;
+    const token = localStorage.getItem('token');
+    const images = [editForm.image1, editForm.image2, editForm.image3].filter(Boolean);
+    try {
+      const res = await axios.put(`http://localhost:5000/api/products/${editProduct._id}`,
+        {
+          name: editForm.name,
+          description: editForm.description,
+          price: Number(editForm.price),
+          images,
+          category: editForm.category,
+          inStock: editForm.inStock,
+          stock: Number(editForm.stock),
+        },
+        { headers: { Authorization: `Bearer ${token}` } });
+      setProducts(prev => prev.map(p => p._id === res.data._id ? res.data : p));
+      setEditProduct(null);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al actualizar');
+    }
+  };
+
+  const handleStockClick = (prod) => {
+    setNewStock(prod.stock || 0);
+    setStockProduct(prod);
+  };
+
+  const handleStockSubmit = async (e) => {
+    e.preventDefault();
+    if (!stockProduct) return;
+    const token = localStorage.getItem('token');
+    try {
+      const res = await axios.put(`http://localhost:5000/api/products/${stockProduct._id}/stock`,
+        { stock: Number(newStock) },
+        { headers: { Authorization: `Bearer ${token}` } });
+      setProducts(prev => prev.map(p => p._id === res.data._id ? res.data : p));
+      setStockProduct(null);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al actualizar stock');
+    }
+  };
+
+  const handleDelete = async (prodId) => {
+    const token = localStorage.getItem('token');
+    if (!window.confirm('¿Eliminar este producto?')) return;
+    try {
+      await axios.delete(`http://localhost:5000/api/products/${prodId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setProducts(prev => prev.filter(p => p._id !== prodId));
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al eliminar');
+    }
   };
 
   return (
@@ -76,11 +164,124 @@ export default function Products() {
                 >
                   Agregar al carrito
                 </button>
+                {role === 'admin' && (
+                  <div className="mt-2">
+                    <button
+                      type="button"
+                      className="btn btn-warning btn-sm me-2"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleEditClick(prod);
+                      }}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm me-2"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleStockClick(prod);
+                      }}
+                    >
+                      Stock
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-danger btn-sm"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleDelete(prod._id);
+                      }}
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </div>
         ))}
       </div>
+      {editProduct && (
+        <div className="modal d-block" tabIndex="-1" onClick={() => setEditProduct(null)}>
+          <div className="modal-dialog" onClick={e => e.stopPropagation()}>
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Editar Producto</h5>
+                <button type="button" className="btn-close" onClick={() => setEditProduct(null)}></button>
+              </div>
+              <form onSubmit={handleEditSubmit}>
+                <div className="modal-body">
+                  <div className="mb-2">
+                    <input className="form-control" placeholder="Título" value={editForm.name}
+                      onChange={e => setEditForm({ ...editForm, name: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <textarea className="form-control" placeholder="Descripción" value={editForm.description}
+                      onChange={e => setEditForm({ ...editForm, description: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input type="number" className="form-control" placeholder="Precio" value={editForm.price}
+                      onChange={e => setEditForm({ ...editForm, price: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input className="form-control" placeholder="Imagen 1" value={editForm.image1}
+                      onChange={e => setEditForm({ ...editForm, image1: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input className="form-control" placeholder="Imagen 2" value={editForm.image2}
+                      onChange={e => setEditForm({ ...editForm, image2: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input className="form-control" placeholder="Imagen 3" value={editForm.image3}
+                      onChange={e => setEditForm({ ...editForm, image3: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input className="form-control" placeholder="Categoría" value={editForm.category}
+                      onChange={e => setEditForm({ ...editForm, category: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <input type="number" className="form-control" placeholder="Stock" value={editForm.stock}
+                      onChange={e => setEditForm({ ...editForm, stock: e.target.value })} />
+                  </div>
+                  <div className="form-check">
+                    <input className="form-check-input" type="checkbox" id="inStockEdit" checked={editForm.inStock}
+                      onChange={e => setEditForm({ ...editForm, inStock: e.target.checked })} />
+                    <label className="form-check-label" htmlFor="inStockEdit">En stock</label>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-secondary" onClick={() => setEditProduct(null)}>Cerrar</button>
+                  <button type="submit" className="btn btn-primary">Guardar</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+      {stockProduct && (
+        <div className="modal d-block" tabIndex="-1" onClick={() => setStockProduct(null)}>
+          <div className="modal-dialog" onClick={e => e.stopPropagation()}>
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Actualizar Stock</h5>
+                <button type="button" className="btn-close" onClick={() => setStockProduct(null)}></button>
+              </div>
+              <form onSubmit={handleStockSubmit}>
+                <div className="modal-body">
+                  <input type="number" className="form-control" value={newStock}
+                    onChange={e => setNewStock(e.target.value)} />
+                </div>
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-secondary" onClick={() => setStockProduct(null)}>Cerrar</button>
+                  <button type="submit" className="btn btn-primary">Guardar</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add admin CRUD routes for products
- allow admins to edit, update stock and delete products from the UI
- add modal forms in `Products.jsx` for editing and stock update

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688365f89dac8320bcdef7b07ec08b14