### PR TITLE
Reduce product card size

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,6 +36,11 @@
   padding: 2em;
 }
 
+.product-card {
+  transform: scale(0.7);
+  transform-origin: top left;
+}
+
 .read-the-docs {
   color: #888;
 }

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -121,7 +121,7 @@ export default function Products() {
       <div className="row">
         {products.map(prod => (
           <div className="col-md-4 mb-3" key={prod._id}>
-            <div className="card h-100" style={{ cursor: 'pointer' }} onClick={() => navigate(`/products/${prod._id}`)}>
+            <div className="card h-100 product-card" style={{ cursor: 'pointer' }} onClick={() => navigate(`/products/${prod._id}`)}>
               {prod.images && prod.images.length > 0 && (
                 <div id={`carousel-${prod._id}`} className="carousel slide">
                   <div className="carousel-inner">


### PR DESCRIPTION
## Summary
- reduce size of product cards by 30% using CSS scale

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68836d6460b48320897638b957323c6f