### PR TITLE
Move logout button inside collapsible menu

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -97,6 +97,15 @@ export default function Navbar() {
               </li>
             )}
           </ul>
+          {token && (
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm mb-2 mb-lg-0"
+              onClick={handleLogout}
+            >
+              Cerrar sesión
+            </button>
+          )}
         </div>
         <form
           className="d-flex me-lg-3 mb-2 mb-lg-0"
@@ -152,13 +161,6 @@ export default function Navbar() {
                 className="d-none"
               />
             </div>
-            <button
-              type="button"
-              className="btn btn-outline-secondary btn-sm mb-2 mb-lg-0"
-              onClick={handleLogout}
-            >
-              Cerrar sesión
-            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- place logout button inside the responsive navbar collapse

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883da7f38b88320b69c381361e4b11e