### PR TITLE
Enable local image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Si al registrarse se proporciona un código que coincida con `ADMIN_CODE`, el us
 
 Tras registrarte recibirás un correo con un enlace para verificar tu cuenta. Hasta que no confirmes tu email no podrás iniciar sesión.
 
+## Subida de imágenes
+
+Los administradores pueden subir imágenes de productos y promociones mediante el endpoint `/api/upload`. Envía un objeto JSON con el campo `data` que contenga la imagen en formato Base64. El servicio responde con la URL que debes guardar en el producto o promoción.
+
 ## Ejecución del frontend
 
 Para evitar el aviso `Cross-Origin-Opener-Policy policy would block the window.postMessage call`, inicia el frontend con el servidor de desarrollo de Vite y no abras `index.html` directamente.

--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import protect from '../middleware/authMiddleware.js';
+import isAdmin from '../middleware/adminMiddleware.js';
+
+const router = express.Router();
+
+router.post('/', protect, isAdmin, (req, res) => {
+  try {
+    const { data } = req.body;
+    if (!data) return res.status(400).json({ message: 'Sin datos' });
+    const match = data.match(/^data:(.+);base64,(.+)$/);
+    if (!match) return res.status(400).json({ message: 'Formato inválido' });
+    const ext = match[1].split('/')[1] || 'png';
+    const buffer = Buffer.from(match[2], 'base64');
+    if (!fs.existsSync('uploads')) fs.mkdirSync('uploads');
+    const filename = `${Date.now()}.${ext}`;
+    fs.writeFileSync(path.join('uploads', filename), buffer);
+    res.json({ url: `/uploads/${filename}` });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import authRoutes from './routes/authRoutes.js';
 import productRoutes from './routes/productRoutes.js';
 import promoRoutes from './routes/promoRoutes.js';
+import uploadRoutes from './routes/uploadRoutes.js';
 
 
 
@@ -13,7 +14,8 @@ dotenv.config();
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '10mb' }));
+app.use('/uploads', express.static('uploads'));
 
 app.get('/', (req, res) => {
   res.send('API Running');
@@ -25,9 +27,10 @@ mongoose.connect(process.env.MONGO_URI, {
 }).then(() => console.log('MongoDB connected'))
   .catch(err => console.error(err));
 
-  app.use('/api/users', authRoutes);
-  app.use('/api/products', productRoutes);
-  app.use('/api/promotions', promoRoutes);
+app.use('/api/users', authRoutes);
+app.use('/api/products', productRoutes);
+app.use('/api/promotions', promoRoutes);
+app.use('/api/upload', uploadRoutes);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/src/pages/AddProduct.jsx
+++ b/frontend/src/pages/AddProduct.jsx
@@ -16,6 +16,21 @@ export default function AddProduct() {
   });
   const navigate = useNavigate();
 
+  const uploadImage = async (file, field) => {
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await axios.post('http://localhost:5000/api/upload', { data: reader.result },
+          { headers: { Authorization: `Bearer ${token}` } });
+        setForm(f => ({ ...f, [field]: res.data.url }));
+      } catch {
+        alert('Error al subir la imagen');
+      }
+    };
+    if (file) reader.readAsDataURL(file);
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     const token = localStorage.getItem('token');
@@ -54,16 +69,19 @@ export default function AddProduct() {
             onChange={(e) => setForm({ ...form, price: e.target.value })} />
         </div>
         <div className="mb-3">
-          <input className="form-control" placeholder="Imagen 1" value={form.image1}
-            onChange={(e) => setForm({ ...form, image1: e.target.value })} />
+          <input type="file" className="form-control" accept="image/*"
+            onChange={e => uploadImage(e.target.files[0], 'image1')} />
+          {form.image1 && <small className="text-muted">{form.image1}</small>}
         </div>
         <div className="mb-3">
-          <input className="form-control" placeholder="Imagen 2" value={form.image2}
-            onChange={(e) => setForm({ ...form, image2: e.target.value })} />
+          <input type="file" className="form-control" accept="image/*"
+            onChange={e => uploadImage(e.target.files[0], 'image2')} />
+          {form.image2 && <small className="text-muted">{form.image2}</small>}
         </div>
         <div className="mb-3">
-          <input className="form-control" placeholder="Imagen 3" value={form.image3}
-            onChange={(e) => setForm({ ...form, image3: e.target.value })} />
+          <input type="file" className="form-control" accept="image/*"
+            onChange={e => uploadImage(e.target.files[0], 'image3')} />
+          {form.image3 && <small className="text-muted">{form.image3}</small>}
         </div>
         <div className="mb-3">
           <input className="form-control" placeholder="Categoría" value={form.category}

--- a/frontend/src/pages/AdminPromos.jsx
+++ b/frontend/src/pages/AdminPromos.jsx
@@ -14,6 +14,21 @@ export default function AdminPromos() {
   });
   const navigate = useNavigate();
 
+  const uploadImage = async (file) => {
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await axios.post('http://localhost:5000/api/upload', { data: reader.result },
+          { headers: { Authorization: `Bearer ${token}` } });
+        setForm(f => ({ ...f, image: res.data.url }));
+      } catch {
+        alert('Error al subir la imagen');
+      }
+    };
+    if (file) reader.readAsDataURL(file);
+  };
+
   useEffect(() => {
     axios.get('http://localhost:5000/api/products')
       .then(res => setProducts(res.data))
@@ -65,8 +80,9 @@ export default function AdminPromos() {
             onChange={e => setForm({ ...form, price: e.target.value })} />
         </div>
         <div className="mb-2">
-          <input className="form-control" placeholder="Imagen (opcional)" value={form.image}
-            onChange={e => setForm({ ...form, image: e.target.value })} />
+          <input type="file" className="form-control" accept="image/*"
+            onChange={e => uploadImage(e.target.files[0])} />
+          {form.image && <small className="text-muted">{form.image}</small>}
         </div>
         <div className="form-check mb-2">
           <input className="form-check-input" type="checkbox" id="activePromo" checked={form.active}

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -25,6 +25,21 @@ export default function Products() {
   const { addItem } = useContext(CartContext);
   const role = localStorage.getItem('role');
 
+  const uploadImage = async (file, field) => {
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await axios.post('http://localhost:5000/api/upload', { data: reader.result },
+          { headers: { Authorization: `Bearer ${token}` } });
+        setEditForm(f => ({ ...f, [field]: res.data.url }));
+      } catch {
+        alert('Error al subir la imagen');
+      }
+    };
+    if (file) reader.readAsDataURL(file);
+  };
+
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const term = params.get('search') || '';
@@ -232,16 +247,19 @@ export default function Products() {
                       onChange={e => setEditForm({ ...editForm, price: e.target.value })} />
                   </div>
                   <div className="mb-2">
-                    <input className="form-control" placeholder="Imagen 1" value={editForm.image1}
-                      onChange={e => setEditForm({ ...editForm, image1: e.target.value })} />
+                    <input type="file" className="form-control" accept="image/*"
+                      onChange={e => uploadImage(e.target.files[0], 'image1')} />
+                    {editForm.image1 && <small className="text-muted">{editForm.image1}</small>}
                   </div>
                   <div className="mb-2">
-                    <input className="form-control" placeholder="Imagen 2" value={editForm.image2}
-                      onChange={e => setEditForm({ ...editForm, image2: e.target.value })} />
+                    <input type="file" className="form-control" accept="image/*"
+                      onChange={e => uploadImage(e.target.files[0], 'image2')} />
+                    {editForm.image2 && <small className="text-muted">{editForm.image2}</small>}
                   </div>
                   <div className="mb-2">
-                    <input className="form-control" placeholder="Imagen 3" value={editForm.image3}
-                      onChange={e => setEditForm({ ...editForm, image3: e.target.value })} />
+                    <input type="file" className="form-control" accept="image/*"
+                      onChange={e => uploadImage(e.target.files[0], 'image3')} />
+                    {editForm.image3 && <small className="text-muted">{editForm.image3}</small>}
                   </div>
                   <div className="mb-2">
                     <input className="form-control" placeholder="Categoría" value={editForm.category}


### PR DESCRIPTION
## Summary
- add `/api/upload` endpoint for base64 image uploads
- serve uploaded images via `/uploads`
- update product and promotion forms to send selected files
- document upload endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68840222dfd0832096e94d370c3f3b35