### PR TITLE
Fix navbar visibility and HMR warning

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,10 +6,9 @@ import Home from './pages/Home.jsx';
 import Navbar from './components/Navbar.jsx';
 
 export default function App() {
-  const token = localStorage.getItem('token');
   return (
     <Router>
-      {token && <Navbar />}
+      <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/register" element={<Register />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -22,7 +22,7 @@ export default function Navbar() {
         <Link className="navbar-brand" to="/">
           Ana<strong>Roma</strong>
         </Link>
-        {token && (
+        {token ? (
           <div className="d-flex align-items-center">
             <div
               className="rounded-circle overflow-hidden d-flex justify-content-center align-items-center me-2"
@@ -42,6 +42,14 @@ export default function Navbar() {
               Cerrar sesión
             </button>
           </div>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-outline-primary btn-sm"
+            onClick={() => navigate('/login')}
+          >
+            Iniciar sesión
+          </button>
         )}
       </div>
     </nav>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,10 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'unsafe-none',
+      'Cross-Origin-Embedder-Policy': 'unsafe-none',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- always render `Navbar` and show login button when user isn't logged in
- disable COOP/COEP headers to silence Vite warning

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68827486a39c8320a7aa64abf6b3b88a