### PR TITLE
Preserve user cart after logout

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -30,17 +30,15 @@ export default function Navbar() {
   const { clearCart } = useContext(CartContext);
 
   const handleLogout = () => {
-    const userId = localStorage.getItem('userId');
-    if (userId) {
-      localStorage.removeItem(`cart_${userId}`);
-    }
-    clearCart();
+    // Preserve the user's cart by keeping the cart_<id> entry in localStorage
+    // Clear the current session and switch to an empty guest cart
     localStorage.removeItem('token');
     localStorage.removeItem('role');
     localStorage.removeItem('name');
     localStorage.removeItem('avatar');
     localStorage.removeItem('userId');
     setAvatar('');
+    clearCart();
     window.dispatchEvent(new Event('userchange'));
     navigate('/login');
   };


### PR DESCRIPTION
## Summary
- keep cart data associated with the user id
- adjust logout logic to clear guest cart only

## Testing
- `npm test` (backend, fails: no test specified)
- `npm test` (frontend, fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6884256308288320be4acd6b08d182fd