### PR TITLE
Add basic order system and gender filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Tras registrarte recibirás un correo con un enlace para verificar tu cuenta. Ha
 
 Los administradores pueden subir imágenes de productos y promociones mediante el endpoint `/api/upload`. Envía un objeto JSON con el campo `data` que contenga la imagen en formato Base64. El servicio responde con la URL que debes guardar en el producto o promoción.
 
+## Órdenes de compra
+
+Al comprar el carrito se crea una orden mediante `/api/orders`. Los usuarios pueden consultar sus órdenes en `/api/orders/my` y los administradores todas las órdenes en `/api/orders`.
+
+## Filtrado por género
+
+Los productos cuentan con el campo `gender` con valores `femenino`, `masculino` o `unisex`. El listado de productos permite filtrar por género usando el parámetro `gender` en la URL.
+
 ## Ejecución del frontend
 
 Para evitar el aviso `Cross-Origin-Opener-Policy policy would block the window.postMessage call`, inicia el frontend con el servidor de desarrollo de Vite y no abras `index.html` directamente.

--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const itemSchema = new mongoose.Schema({
+  product: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', required: true },
+  quantity: { type: Number, required: true },
+  price: { type: Number, required: true },
+});
+
+const orderSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  items: [itemSchema],
+  total: { type: Number, required: true },
+  status: { type: String, default: 'pendiente' },
+}, { timestamps: true });
+
+export default mongoose.model('Order', orderSchema);

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -9,6 +9,11 @@ const productSchema = new mongoose.Schema({
     validate: [arr => arr.length <= 3, 'Máximo 3 imágenes']
   },
   category: String,
+  gender: {
+    type: String,
+    enum: ['femenino', 'masculino', 'unisex'],
+    default: 'unisex'
+  },
   inStock: { type: Boolean, default: true },
   stock: { type: Number, default: 0 },
 }, {

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import Order from '../models/Order.js';
+import Product from '../models/Product.js';
+import protect from '../middleware/authMiddleware.js';
+import isAdmin from '../middleware/adminMiddleware.js';
+
+const router = express.Router();
+
+// Crear una orden a partir de items
+router.post('/', protect, async (req, res) => {
+  const { items } = req.body;
+  if (!Array.isArray(items) || items.length === 0) {
+    return res.status(400).json({ message: 'Sin items' });
+  }
+  try {
+    const populated = await Promise.all(items.map(async ({ product, quantity }) => {
+      const prod = await Product.findById(product);
+      if (!prod) throw new Error('Producto no encontrado');
+      return { product: prod._id, quantity, price: prod.price };
+    }));
+    const total = populated.reduce((sum, i) => sum + i.price * i.quantity, 0);
+    const order = await Order.create({ user: req.user._id, items: populated, total });
+    res.status(201).json(order);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Obtener mis ordenes
+router.get('/my', protect, async (req, res) => {
+  const orders = await Order.find({ user: req.user._id }).populate('items.product');
+  res.json(orders);
+});
+
+// Obtener todas las ordenes (admin)
+router.get('/', protect, isAdmin, async (req, res) => {
+  const orders = await Order.find().populate('user', 'name email');
+  res.json(orders);
+});
+
+// Obtener una orden
+router.get('/:id', protect, async (req, res) => {
+  try {
+    const order = await Order.findById(req.params.id).populate('items.product');
+    if (!order) return res.status(404).json({ message: 'Orden no encontrada' });
+    if (order.user.toString() !== req.user._id.toString() && req.user.role !== 'admin') {
+      return res.status(403).json({ message: 'Sin permiso' });
+    }
+    res.json(order);
+  } catch (err) {
+    res.status(400).json({ message: 'Id inválido' });
+  }
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ import authRoutes from './routes/authRoutes.js';
 import productRoutes from './routes/productRoutes.js';
 import promoRoutes from './routes/promoRoutes.js';
 import uploadRoutes from './routes/uploadRoutes.js';
+import orderRoutes from './routes/orderRoutes.js';
 
 
 
@@ -31,6 +32,7 @@ app.use('/api/users', authRoutes);
 app.use('/api/products', productRoutes);
 app.use('/api/promotions', promoRoutes);
 app.use('/api/upload', uploadRoutes);
+app.use('/api/orders', orderRoutes);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Products from './pages/Products.jsx';
 import ProductDetail from './pages/ProductDetail.jsx';
 import AddProduct from './pages/AddProduct.jsx';
 import AdminPromos from './pages/AdminPromos.jsx';
+import AdminOrders from './pages/AdminOrders.jsx';
 import Cart from './pages/Cart.jsx';
 import Navbar from './components/Navbar.jsx';
 import { CartProvider } from './context/CartContext.jsx';
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="/products/:id" element={<ProductDetail />} />
           <Route path="/add-product" element={<AddProduct />} />
           <Route path="/admin/promos" element={<AdminPromos />} />
+          <Route path="/admin/orders" element={<AdminOrders />} />
           <Route path="/cart" element={<Cart />} />
         </Routes>
       </Router>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -123,6 +123,11 @@ export default function Navbar() {
                     Promociones
                   </Link>
                 </li>
+                <li className="nav-item">
+                  <Link className="nav-link" to="/admin/orders">
+                    Órdenes
+                  </Link>
+                </li>
               </>
             )}
           </ul>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #333;
+  background: linear-gradient(to bottom, #fff, #ffeaf5);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,11 +15,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #d63384;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #b52e6c;
 }
 
 body {

--- a/frontend/src/pages/AddProduct.jsx
+++ b/frontend/src/pages/AddProduct.jsx
@@ -11,6 +11,7 @@ export default function AddProduct() {
     image2: '',
     image3: '',
     category: '',
+    gender: 'unisex',
     inStock: true,
     stock: 0,
   });
@@ -42,6 +43,7 @@ export default function AddProduct() {
         price: Number(form.price),
         images,
         category: form.category,
+        gender: form.gender,
         inStock: form.inStock,
         stock: Number(form.stock),
       }, { headers: { Authorization: `Bearer ${token}` } });
@@ -86,6 +88,14 @@ export default function AddProduct() {
         <div className="mb-3">
           <input className="form-control" placeholder="Categoría" value={form.category}
             onChange={(e) => setForm({ ...form, category: e.target.value })} />
+        </div>
+        <div className="mb-3">
+          <select className="form-select" value={form.gender}
+            onChange={e => setForm({ ...form, gender: e.target.value })}>
+            <option value="unisex">Unisex</option>
+            <option value="femenino">Para Ella</option>
+            <option value="masculino">Para Él</option>
+          </select>
         </div>
         <div className="mb-3">
           <input type="number" className="form-control" placeholder="Stock" value={form.stock}

--- a/frontend/src/pages/AdminOrders.jsx
+++ b/frontend/src/pages/AdminOrders.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export default function AdminOrders() {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    axios.get('http://localhost:5000/api/orders', {
+      headers: { Authorization: `Bearer ${token}` }
+    }).then(res => setOrders(res.data))
+      .catch(() => alert('Error al obtener órdenes'));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h2 className="mb-4">Órdenes</h2>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Usuario</th>
+            <th>Total</th>
+            <th>Fecha</th>
+            <th>Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map(o => (
+            <tr key={o._id}>
+              <td>{o.user?.name}</td>
+              <td>${o.total}</td>
+              <td>{new Date(o.createdAt).toLocaleDateString()}</td>
+              <td>{o.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -1,10 +1,26 @@
 import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CartContext from '../context/CartContext.jsx';
+import axios from 'axios';
 
 export default function Cart() {
-  const { items, total, removeItem } = useContext(CartContext);
+  const { items, total, removeItem, clearCart } = useContext(CartContext);
   const navigate = useNavigate();
+
+  const handlePurchase = async () => {
+    if (items.length === 0) return;
+    const token = localStorage.getItem('token');
+    try {
+      await axios.post('http://localhost:5000/api/orders', {
+        items: items.map(i => ({ product: i.product._id, quantity: i.quantity }))
+      }, { headers: { Authorization: `Bearer ${token}` } });
+      alert('Orden creada');
+      clearCart();
+      navigate('/');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al crear orden');
+    }
+  };
 
   return (
     <div className="container mt-4">
@@ -40,7 +56,7 @@ export default function Cart() {
         </>
       )}
       <div className="mt-3">
-        <button type="button" className="btn btn-primary me-2">
+        <button type="button" className="btn btn-primary me-2" onClick={handlePurchase}>
           Comprar Carrito
         </button>
         <button

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -15,6 +15,7 @@ export default function Products() {
     image2: '',
     image3: '',
     category: '',
+    gender: 'unisex',
     inStock: true,
     stock: 0,
   });
@@ -43,9 +44,13 @@ export default function Products() {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const term = params.get('search') || '';
+    const gender = params.get('gender') || '';
+    const query = {};
+    if (term) query.search = term;
+    if (gender) query.gender = gender;
     axios
       .get('http://localhost:5000/api/products', {
-        params: term ? { search: term } : {},
+        params: query,
       })
       .then((res) => setProducts(res.data))
       .catch(() => alert('Error al obtener productos'));
@@ -73,6 +78,7 @@ export default function Products() {
       image2: img2,
       image3: img3,
       category: prod.category || '',
+      gender: prod.gender || 'unisex',
       inStock: prod.inStock,
       stock: prod.stock || 0,
     });
@@ -92,6 +98,7 @@ export default function Products() {
           price: Number(editForm.price),
           images,
           category: editForm.category,
+          gender: editForm.gender,
           inStock: editForm.inStock,
           stock: Number(editForm.stock),
         },
@@ -139,6 +146,19 @@ export default function Products() {
   return (
     <div className="container mt-4">
       <h2 className="mb-4">Productos</h2>
+      <div className="mb-3">
+        <select className="form-select w-auto" value={new URLSearchParams(location.search).get('gender') || ''}
+          onChange={e => {
+            const params = new URLSearchParams(location.search);
+            if (e.target.value) params.set('gender', e.target.value); else params.delete('gender');
+            navigate(`/products?${params.toString()}`);
+          }}>
+          <option value="">Todos</option>
+          <option value="femenino">Para Ella</option>
+          <option value="masculino">Para Él</option>
+          <option value="unisex">Unisex</option>
+        </select>
+      </div>
       <div className="row">
         {products.map(prod => (
           <div className="col-sm-6 col-md-3 mb-3" key={prod._id}>
@@ -264,6 +284,14 @@ export default function Products() {
                   <div className="mb-2">
                     <input className="form-control" placeholder="Categoría" value={editForm.category}
                       onChange={e => setEditForm({ ...editForm, category: e.target.value })} />
+                  </div>
+                  <div className="mb-2">
+                    <select className="form-select" value={editForm.gender}
+                      onChange={e => setEditForm({ ...editForm, gender: e.target.value })}>
+                      <option value="unisex">Unisex</option>
+                      <option value="femenino">Para Ella</option>
+                      <option value="masculino">Para Él</option>
+                    </select>
                   </div>
                   <div className="mb-2">
                     <input type="number" className="form-control" placeholder="Stock" value={editForm.stock}


### PR DESCRIPTION
## Summary
- add gender field to products
- implement orders model and routes
- expose orders API in server
- allow gender selection when creating or editing products
- filter product list by gender
- implement cart purchase that creates orders
- admin orders page and navbar link
- update style with pink theme
- document new features

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails to run eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6884c0872610832098ef6c06a8594f18