### PR TITLE
Hide navbar on logout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import Register from './pages/Register.jsx';
 import Login from './pages/Login.jsx';
 import Profile from './pages/Profile.jsx';
@@ -13,10 +14,18 @@ import Navbar from './components/Navbar.jsx';
 import { CartProvider } from './context/CartContext.jsx';
 
 export default function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  useEffect(() => {
+    const handler = () => setToken(localStorage.getItem('token'));
+    window.addEventListener('userchange', handler);
+    return () => window.removeEventListener('userchange', handler);
+  }, []);
+
   return (
     <CartProvider>
       <Router>
-        <Navbar />
+        {token && <Navbar />}
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/register" element={<Register />} />


### PR DESCRIPTION
## Summary
- hide the navbar when the user is not logged in by reading the token in `App.jsx`
- listen to `userchange` events to update navbar visibility

## Testing
- `npm run lint` *(fails: Cannot find package `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_6884c45f43848320973f394d6bc94da5