### PR TITLE
Update promo banner and avatar sizes

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -125,6 +125,7 @@ export default function Navbar() {
     backgroundColor: '#e53752',
     borderTopLeftRadius: '8px',
     borderTopRightRadius: '8px',
+    width: '100%',
     fontFamily: '"Dream avenue", sans-serif',
     color: '#fff3f5',
     padding: '4px',
@@ -135,6 +136,8 @@ export default function Navbar() {
     backgroundColor: '#fff3f5',
     color: '#e53752',
     borderBottomRightRadius: '8px',
+    borderBottomLeftRadius: '8px',
+    width: '100%',
     fontFamily: '"Dream avenue", sans-serif',
     padding: '4px',
     fontSize: '0.8rem',
@@ -227,8 +230,8 @@ export default function Navbar() {
                 <div
                   className="rounded-circle overflow-hidden d-flex justify-content-center align-items-center me-2"
                   style={{
-                    width: '60px',
-                    height: '60px',
+                    width: '42px',
+                    height: '42px',
                     border: '1px solid black',
                     cursor: 'pointer',
                   }}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -57,7 +57,7 @@ export default function Profile() {
             {avatar && (
               <div
                 className="rounded-circle overflow-hidden"
-                style={{ width: '100px', height: '100px', border: '1px solid black', cursor: 'pointer' }}
+                style={{ width: '70px', height: '70px', border: '1px solid black', cursor: 'pointer' }}
                 onClick={handleImageClick}
               >
                 <img src={avatar} alt="Avatar" className="w-100 h-100" />


### PR DESCRIPTION
## Summary
- ensure promo banner rectangles fill full width
- add matching bottom-left radius
- shrink navbar avatar
- shrink profile avatar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887845ccc848320a5a5fd1a180553ea