### PR TITLE
Expand promo banners

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -116,7 +116,7 @@ export default function Navbar() {
   const initial = name.charAt(0).toUpperCase();
   const cartCount = items.reduce((sum, i) => sum + i.quantity, 0);
   const promoContainerStyle = {
-    width: '160px',
+    width: '240px',
     lineHeight: 1,
     textAlign: 'center',
   };


### PR DESCRIPTION
## Summary
- adjust promo banner container width so rectangles appear 50% wider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68878bf7e34483208848dc0d17e3c625