### PR TITLE
Update navbar for guests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,7 @@ export default function App() {
   return (
     <CartProvider>
       <Router>
-        {token && <Navbar />}
+        <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/register" element={<Register />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -225,7 +225,7 @@ export default function Navbar() {
                 </span>
               )}
             </Link>
-            {token && (
+            {token ? (
               <>
                 <div
                   className="rounded-circle overflow-hidden d-flex justify-content-center align-items-center me-2"
@@ -257,6 +257,21 @@ export default function Navbar() {
                 >
                   Cerrar sesión
                 </button>
+              </>
+            ) : (
+              <>
+                <Link
+                  to="/login"
+                  className="btn btn-outline-light btn-sm me-2"
+                >
+                  Iniciar sesión
+                </Link>
+                <Link
+                  to="/register"
+                  className="btn btn-outline-light btn-sm me-2"
+                >
+                  Registrarse
+                </Link>
               </>
             )}
             <button

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -57,6 +57,12 @@ export default function Products() {
   }, [location.search]);
 
   const handleAdd = async (prod) => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      alert('Debes iniciar sesión para agregar productos');
+      navigate('/login');
+      return;
+    }
     const qty = Number(quantities[prod._id] || 1);
     if (qty <= 0) return;
     if (qty > prod.stock) {
@@ -198,6 +204,7 @@ export default function Products() {
                 <button
                   type="button"
                   className="btn btn-primary"
+                  disabled={!localStorage.getItem('token')}
                   onClick={e => {
                     e.stopPropagation();
                     handleAdd(prod);


### PR DESCRIPTION
## Summary
- always show `Navbar`
- show login/register buttons for guests
- disallow adding products to cart if not logged in

## Testing
- `npm run lint` *(fails: Cannot find package `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_6887939e9f148320a4a619e5e086256c