### PR TITLE
Hide promo banners on small screens

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -168,8 +168,7 @@ export default function Navbar() {
             Ana<strong>Roma</strong>
           </Link>
           <form
-            className="d-flex flex-grow-1 mx-3"
-            style={{ maxWidth: '50vw' }}
+            className="d-flex flex-grow-1 mx-3 search-form"
             onSubmit={handleSearch}
           >
             <input
@@ -183,7 +182,7 @@ export default function Navbar() {
               Buscar
             </button>
           </form>
-          <div className="d-flex flex-column align-items-center ms-3" style={promoContainerStyle}>
+          <div className="d-none d-md-flex flex-column align-items-center ms-3" style={promoContainerStyle}>
             <div style={promoTopStyle}>PROMOCIONES Y DESCUENTOS</div>
             <div style={promoBottomStyle}>En cada compra</div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -64,3 +64,13 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.search-form {
+  max-width: 50vw;
+}
+
+@media (max-width: 768px) {
+  .search-form {
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
- make promotions section responsive by hiding it on small screens
- allow the search bar to fill the freed space on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888e08a19688320a016e2406b8c411b