### PR TITLE
Align carousel with navbar

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,7 +11,7 @@ export default function Home() {
 
   return (
     <>
-      <div className="container-fluid p-0 mt-3">
+      <div className="container-fluid p-0">
         <div
           id="homeCarousel"
           className="carousel slide"


### PR DESCRIPTION
## Summary
- remove top margin from the home page carousel so it sits flush with the navbar

## Testing
- `npm --prefix frontend run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_688a1a2786e48320a9ec7e065ce8cf61