### PR TITLE
Add gradient band below home carousel

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -74,3 +74,9 @@ button:focus-visible {
     max-width: none;
   }
 }
+
+.carousel-overlay {
+  width: 100%;
+  height: 200px;
+  background: linear-gradient(to bottom, rgba(255,255,255,0) 50%, #ffeaf5 100%);
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -79,6 +79,7 @@ export default function Home() {
           </button>
         </div>
       </div>
+      <div className="carousel-overlay" />
 
       <div className="container mt-5">
         {promos.length > 0 && (


### PR DESCRIPTION
## Summary
- add gradient band after carousel on Home page
- style gradient overlay in global CSS

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/E-commers/frontend/node_modules/globals/index.js' imported from /workspace/E-commers/frontend/eslint.config.js)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1d5a81d08320a9529caf9c7e1eea