### PR TITLE
Fix carousel image paths and promo card visibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,11 +78,13 @@ button:focus-visible {
 .carousel-overlay {
   width: 100%;
   height: 200px;
+  margin-top: -200px;
+  pointer-events: none;
   background: linear-gradient(to bottom, rgba(255,255,255,0) 50%, #ffeaf5 100%);
 }
 
 .promo-slider-wrapper {
-  transform: translateY(-35%);
+  /* Removing transform ensures promo cards remain visible under the carousel */
 }
 
 .promo-card {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -32,7 +32,7 @@ export default function Home() {
           <div className="carousel-inner">
             <div className="carousel-item active">
               <img
-                src="http://localhost:5000/uploads/carrousel1.png"
+                src="http://localhost:5000/uploads/carousel1.png"
                 className="d-block w-100"
                 alt="Slide 1"
                 style={{ maxHeight: '400px', objectFit: 'cover' }}
@@ -40,7 +40,7 @@ export default function Home() {
             </div>
             <div className="carousel-item">
               <img
-                src="http://localhost:5000/uploads/carrousel2.png"
+                src="http://localhost:5000/uploads/carousel2.png"
                 className="d-block w-100"
                 alt="Slide 2"
                 style={{ maxHeight: '400px', objectFit: 'cover' }}
@@ -48,7 +48,7 @@ export default function Home() {
             </div>
             <div className="carousel-item">
               <img
-                src="http://localhost:5000/uploads/carrousel3.png"
+                src="http://localhost:5000/uploads/carousel3.png"
                 className="d-block w-100"
                 alt="Slide 3"
                 style={{ maxHeight: '400px', objectFit: 'cover' }}
@@ -56,7 +56,7 @@ export default function Home() {
             </div>
             <div className="carousel-item">
               <img
-                src="http://localhost:5000/uploads/carrousel4.png"
+                src="http://localhost:5000/uploads/carousel4.png"
                 className="d-block w-100"
                 alt="Slide 4"
                 style={{ maxHeight: '400px', objectFit: 'cover' }}
@@ -64,7 +64,7 @@ export default function Home() {
             </div>
             <div className="carousel-item">
               <img
-                src="http://localhost:5000/uploads/carrousel5.png"
+                src="http://localhost:5000/uploads/carousel5.png"
                 className="d-block w-100"
                 alt="Slide 5"
                 style={{ maxHeight: '400px', objectFit: 'cover' }}


### PR DESCRIPTION
## Summary
- Correct carousel image URLs so slides render
- Adjust overlay CSS to avoid hiding promotional cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_688b7127e7a88320aee2f4e51036ec00