### PR TITLE
Reposition carousel blur overlay

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,16 +77,17 @@ button:focus-visible {
 
 .carousel-wrapper {
   position: relative;
+  z-index: 0;
 }
 
 .carousel-overlay {
   position: absolute;
-  bottom: 0;
+  top: 100%;
   left: 0;
   width: 100%;
   height: 200px;
   pointer-events: none;
-  z-index: 1;
+  z-index: -1;
 }
 
 .promo-slider-wrapper {


### PR DESCRIPTION
## Summary
- Repositioned the home carousel's blur overlay so it sits below the carousel and behind promo cards

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/E-commers/frontend/node_modules/globals/index.js')*
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/E-commers/frontend/node_modules/acorn')*

------
https://chatgpt.com/codex/tasks/task_e_688b80310f888320941d4d4ca54f178c