### PR TITLE
fix: invert carousel overlay gradient direction

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -137,7 +137,7 @@ export default function Home() {
         </div>
         <div
           className="carousel-overlay"
-          style={{ background: `linear-gradient(to bottom, rgba(${overlayColor},0) 0%, rgba(${overlayColor},1) 100%)` }}
+          style={{ background: `linear-gradient(to bottom, rgba(${overlayColor},1) 0%, rgba(${overlayColor},0) 100%)` }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- invert carousel overlay gradient so darker side is next to carousel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '/workspace/E-commers/frontend/node_modules/globals/index.js' imported from /workspace/E-commers/frontend/eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_688b83b709588320b203bb166d7efa63