### PR TITLE
Add weekly featured products and admin highlight button

### DIFF
--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -16,6 +16,7 @@ const productSchema = new mongoose.Schema({
   },
   inStock: { type: Boolean, default: true },
   stock: { type: Number, default: 0 },
+  featured: { type: Boolean, default: false },
 }, {
   timestamps: true,
 });

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -27,6 +27,16 @@ router.get('/', async (req, res) => {
   }
 });
 
+// Obtener productos destacados
+router.get('/featured', async (req, res) => {
+  try {
+    const featured = await Product.find({ featured: true }).sort({ updatedAt: -1 }).limit(6);
+    res.json(featured);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 // Obtener producto por ID
 router.get('/:id', async (req, res) => {
   try {
@@ -64,6 +74,24 @@ router.patch('/:id/stock', async (req, res) => {
     }
     product.stock = newStock;
     await product.save();
+    res.json(product);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Marcar un producto como destacado
+router.put('/:id/featured', protect, isAdmin, async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Producto no encontrado' });
+    product.featured = true;
+    await product.save();
+    const extras = await Product.find({ featured: true }).sort({ updatedAt: -1 }).skip(6);
+    for (const p of extras) {
+      p.featured = false;
+      await p.save();
+    }
     res.json(product);
   } catch (err) {
     res.status(400).json({ message: err.message });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,3 +104,12 @@ button:focus-visible {
   border-radius: 50%;
   padding: 0;
 }
+
+.featured-card {
+  width: 100%;
+  min-height: 260px;
+}
+
+.featured-img {
+  width: 60%;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,10 +4,17 @@ export default function Home() {
   const [promos, setPromos] = useState([]);
   const [startIndex, setStartIndex] = useState(0);
   const [overlayColor, setOverlayColor] = useState('255,234,245');
+  const [featured, setFeatured] = useState([]);
 
   useEffect(() => {
     axios.get('http://localhost:5000/api/promotions')
       .then(res => setPromos(res.data))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/products/featured')
+      .then(res => setFeatured(res.data))
       .catch(() => {});
   }, []);
 
@@ -179,6 +186,37 @@ export default function Home() {
           </div>
         </div>
       )}
+
+      <div className="container mt-4">
+        <div className="row g-0 justify-content-center">
+          {Array.from({ length: 6 }).map((_, i) => {
+            const prod = featured[i];
+            if (!prod) {
+              return (
+                <div key={i} className="col-6 col-md-2">
+                  <div className="card h-100 featured-card" />
+                </div>
+              );
+            }
+            const images = prod.images || [];
+            const img = images.length > 0 ? images[Math.floor(Math.random() * images.length)] : null;
+            return (
+              <div key={prod._id} className="col-6 col-md-2">
+                <div className="card h-100 featured-card text-center">
+                  <div className="card-body d-flex flex-column align-items-center p-2">
+                    <h6 className="card-title mb-2">{prod.name}</h6>
+                    {img && (
+                      <img src={img} alt={prod.name} className="featured-img mb-2" style={{ objectFit: 'cover' }} />
+                    )}
+                    <p className="card-text mb-1">{prod.description}</p>
+                    <p className="card-text fw-bold mb-0">${prod.price}</p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </>
   );
 }

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -149,6 +149,18 @@ export default function Products() {
     }
   };
 
+  const handleFeatured = async (id) => {
+    const token = localStorage.getItem('token');
+    try {
+      await axios.put(`http://localhost:5000/api/products/${id}/featured`, {}, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      alert('Producto marcado como destacado');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error al marcar como destacado');
+    }
+  };
+
   return (
     <div className="container mt-4">
       <h2 className="mb-4">Productos</h2>
@@ -214,6 +226,16 @@ export default function Products() {
                 </button>
                 {role === 'admin' && (
                   <div className="mt-2">
+                    <button
+                      type="button"
+                      className="btn btn-info btn-sm me-2"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleFeatured(prod._id);
+                      }}
+                    >
+                      Destacado
+                    </button>
                     <button
                       type="button"
                       className="btn btn-warning btn-sm me-2"


### PR DESCRIPTION
## Summary
- show weekly featured products on home
- allow admins to mark products as featured

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` *(frontend, fails: 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c3527960883208ea715ca1b78b896