### PR TITLE
Add category preview cards to home page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -124,3 +124,22 @@ button:focus-visible {
   padding: 20px 0;
   background: linear-gradient(to bottom, rgba(128,128,128,0), #e0e0e0 20%, #e0e0e0 80%, rgba(128,128,128,0));
 }
+
+.category-card {
+  width: 100%;
+  min-height: 260px;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.category-main-img {
+  width: 100%;
+  flex: 0 0 60%;
+}
+
+.category-thumb {
+  width: 48%;
+  aspect-ratio: 1/1;
+  cursor: pointer;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,6 +8,7 @@ export default function Home() {
   const [featured, setFeatured] = useState([]);
   const [highlightCategory, setHighlightCategory] = useState('');
   const [categoryProducts, setCategoryProducts] = useState([]);
+  const [categoryPreviews, setCategoryPreviews] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -32,6 +33,22 @@ export default function Home() {
             .then(r => setCategoryProducts(r.data))
             .catch(() => {});
         }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/products')
+      .then(res => {
+        const products = res.data;
+        const categories = Array.from(new Set(products.map(p => p.category).filter(Boolean)));
+        const previews = categories.slice(0, 3).map(cat => {
+          const catProducts = products.filter(p => p.category === cat);
+          const mainImage = catProducts[0]?.images?.[0] || null;
+          const images = catProducts.slice(0, 4).map(p => p.images?.[0]).filter(Boolean);
+          return { category: cat, mainImage, images };
+        });
+        setCategoryPreviews(previews);
       })
       .catch(() => {});
   }, []);
@@ -282,6 +299,43 @@ export default function Home() {
                   </div>
                 );
               })}
+            </div>
+          </div>
+        </div>
+      )}
+      {categoryPreviews.length > 0 && (
+        <div className="featured-section mt-4">
+          <div className="container">
+            <div className="row g-3 justify-content-center">
+              {categoryPreviews.map(preview => (
+                <div key={preview.category} className="col-12 col-md-4">
+                  <div className="card h-100 category-card text-center">
+                    <div className="card-body d-flex flex-column p-2">
+                      <h6 className="card-title mb-2">{preview.category}</h6>
+                      {preview.mainImage && (
+                        <img
+                          src={preview.mainImage}
+                          alt={preview.category}
+                          className="category-main-img mb-2"
+                          style={{ objectFit: 'cover' }}
+                        />
+                      )}
+                      <div className="mt-auto d-flex flex-wrap justify-content-between gap-1">
+                        {preview.images.map((img, idx) => (
+                          <img
+                            key={idx}
+                            src={img}
+                            alt={`${preview.category}-${idx}`}
+                            className="category-thumb"
+                            style={{ objectFit: 'cover', cursor: 'pointer' }}
+                            onClick={() => navigate(`/products?category=${encodeURIComponent(preview.category)}`)}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -45,9 +45,11 @@ export default function Products() {
     const params = new URLSearchParams(location.search);
     const term = params.get('search') || '';
     const gender = params.get('gender') || '';
+    const category = params.get('category') || '';
     const query = {};
     if (term) query.search = term;
     if (gender) query.gender = gender;
+    if (category) query.category = category;
     axios
       .get('http://localhost:5000/api/products', {
         params: query,


### PR DESCRIPTION
## Summary
- show three category preview cards with main image and product thumbnails on home page
- support category filtering in products page
- add styles for category previews

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cc996ef9083208b9598ad41523c05