### PR TITLE
Adjust category image proportions and layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,11 +135,11 @@ button:focus-visible {
 
 .category-main-img {
   width: 100%;
-  flex: 0 0 60%;
+  height: 60%;
 }
 
 .category-thumb {
-  width: 48%;
+  width: 23%;
   aspect-ratio: 1/1;
   cursor: pointer;
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -310,7 +310,7 @@ export default function Home() {
               {categoryPreviews.map(preview => (
                 <div key={preview.category} className="col-12 col-md-4">
                   <div className="card h-100 category-card text-center">
-                    <div className="card-body d-flex flex-column p-2">
+                    <div className="card-body d-flex flex-column p-2 h-100">
                       <h6 className="card-title mb-2">{preview.category}</h6>
                       {preview.mainImage && (
                         <img
@@ -320,7 +320,7 @@ export default function Home() {
                           style={{ objectFit: 'cover' }}
                         />
                       )}
-                      <div className="mt-auto d-flex flex-wrap justify-content-between gap-1">
+                      <div className="mt-auto d-flex justify-content-between gap-1">
                         {preview.images.map((img, idx) => (
                           <img
                             key={idx}


### PR DESCRIPTION
## Summary
- Ensure category cards display main images at 60% of card height
- Keep all category thumbnails aligned on a single row

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ccd571d5c83209742a465f78f5470