### PR TITLE
Allow admin category images and match card backgrounds

### DIFF
--- a/backend/models/CategoryImage.js
+++ b/backend/models/CategoryImage.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const categoryImageSchema = new mongoose.Schema({
+  category: { type: String, required: true, unique: true },
+  image: { type: String, required: true },
+}, {
+  timestamps: true,
+});
+
+export default mongoose.model('CategoryImage', categoryImageSchema);

--- a/backend/routes/categoryImageRoutes.js
+++ b/backend/routes/categoryImageRoutes.js
@@ -1,0 +1,37 @@
+import express from 'express';
+import protect from '../middleware/authMiddleware.js';
+import isAdmin from '../middleware/adminMiddleware.js';
+import CategoryImage from '../models/CategoryImage.js';
+
+const router = express.Router();
+
+// Get all category images
+router.get('/', async (req, res) => {
+  try {
+    const images = await CategoryImage.find();
+    res.json(images);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// Set image for a specific category
+router.put('/:category', protect, isAdmin, async (req, res) => {
+  const { category } = req.params;
+  const { image } = req.body;
+  if (!image) return res.status(400).json({ message: 'Imagen requerida' });
+  try {
+    let doc = await CategoryImage.findOne({ category });
+    if (doc) {
+      doc.image = image;
+    } else {
+      doc = new CategoryImage({ category, image });
+    }
+    await doc.save();
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ import promoRoutes from './routes/promoRoutes.js';
 import uploadRoutes from './routes/uploadRoutes.js';
 import orderRoutes from './routes/orderRoutes.js';
 import highlightRoutes from './routes/highlightRoutes.js';
+import categoryImageRoutes from './routes/categoryImageRoutes.js';
 
 
 
@@ -35,6 +36,7 @@ app.use('/api/promotions', promoRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api/highlight-category', highlightRoutes);
+app.use('/api/category-images', categoryImageRoutes);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,6 +98,7 @@ button:focus-visible {
   width: 100%;
   border: none;
   box-shadow: none;
+  background-color: #FFC9C9;
 }
 
 .promo-next-btn {
@@ -113,6 +114,7 @@ button:focus-visible {
   border: none;
   border-radius: 0;
   box-shadow: none;
+  background-color: #FFC9C9;
 }
 
 .featured-img {
@@ -131,6 +133,7 @@ button:focus-visible {
   border: none;
   border-radius: 0;
   box-shadow: none;
+  background-color: #FFC9C9;
 }
 
 .category-main-img {
@@ -142,4 +145,8 @@ button:focus-visible {
   width: 23%;
   aspect-ratio: 1/1;
   cursor: pointer;
+}
+
+.product-card {
+  background-color: #FFC9C9;
 }

--- a/frontend/src/pages/AdminCategory.jsx
+++ b/frontend/src/pages/AdminCategory.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 export default function AdminCategory() {
   const [categories, setCategories] = useState([]);
   const [selected, setSelected] = useState('');
+  const [images, setImages] = useState({});
 
   useEffect(() => {
     axios.get('http://localhost:5000/api/products')
@@ -14,6 +15,15 @@ export default function AdminCategory() {
       .catch(() => {});
     axios.get('http://localhost:5000/api/highlight-category')
       .then(res => setSelected(res.data?.category || ''))
+      .catch(() => {});
+    axios.get('http://localhost:5000/api/category-images')
+      .then(res => {
+        const map = res.data.reduce((acc, cur) => {
+          acc[cur.category] = cur.image;
+          return acc;
+        }, {});
+        setImages(map);
+      })
       .catch(() => {});
   }, []);
 
@@ -30,6 +40,31 @@ export default function AdminCategory() {
     }
   };
 
+  const handleImageUpload = async (file) => {
+    if (!selected) {
+      alert('Seleccione una categoría');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const uploadRes = await axios.post('http://localhost:5000/api/upload', { data: reader.result }, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const url = uploadRes.data.url;
+        await axios.put(`http://localhost:5000/api/category-images/${selected}`, { image: url }, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setImages(imgs => ({ ...imgs, [selected]: url }));
+        alert('Imagen actualizada');
+      } catch {
+        alert('Error al subir la imagen');
+      }
+    };
+    if (file) reader.readAsDataURL(file);
+  };
+
   return (
     <div className="container mt-4">
       <h2 className="mb-4">Categoría destacada</h2>
@@ -41,6 +76,10 @@ export default function AdminCategory() {
               <option key={cat} value={cat}>{cat}</option>
             ))}
           </select>
+        </div>
+        <div className="mb-3">
+          <input type="file" className="form-control" accept="image/*" onChange={e => handleImageUpload(e.target.files[0])} />
+          {images[selected] && <small className="text-muted">{images[selected]}</small>}
         </div>
         <button type="submit" className="btn btn-primary">Guardar</button>
       </form>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -38,19 +38,30 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    axios.get('http://localhost:5000/api/products')
-      .then(res => {
-        const products = res.data;
+    const fetchPreviews = async () => {
+      try {
+        const [prodRes, imgRes] = await Promise.all([
+          axios.get('http://localhost:5000/api/products'),
+          axios.get('http://localhost:5000/api/category-images'),
+        ]);
+        const products = prodRes.data;
+        const imgMap = imgRes.data.reduce((acc, cur) => {
+          acc[cur.category] = cur.image;
+          return acc;
+        }, {});
         const categories = Array.from(new Set(products.map(p => p.category).filter(Boolean)));
         const previews = categories.slice(0, 3).map(cat => {
           const catProducts = products.filter(p => p.category === cat);
-          const mainImage = catProducts[0]?.images?.[0] || null;
+          const mainImage = imgMap[cat] || catProducts[0]?.images?.[0] || null;
           const images = catProducts.slice(0, 4).map(p => p.images?.[0]).filter(Boolean);
           return { category: cat, mainImage, images };
         });
         setCategoryPreviews(previews);
-      })
-      .catch(() => {});
+      } catch {
+        // ignore
+      }
+    };
+    fetchPreviews();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- let admins upload custom images per category
- use those images on home page category cards
- make all cards use navbar background color

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cd026e1348320aa605b2d1caf7591