### PR TITLE
Limit navbar color to featured category cards

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -98,7 +98,7 @@ button:focus-visible {
   width: 100%;
   border: none;
   box-shadow: none;
-  background-color: #FFC9C9;
+  background-color: #fff;
 }
 
 .promo-next-btn {
@@ -114,7 +114,7 @@ button:focus-visible {
   border: none;
   border-radius: 0;
   box-shadow: none;
-  background-color: #FFC9C9;
+  background-color: #fff;
 }
 
 .featured-img {
@@ -148,5 +148,5 @@ button:focus-visible {
 }
 
 .product-card {
-  background-color: #FFC9C9;
+  background-color: #fff;
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -327,11 +327,11 @@ export default function Home() {
                         <img
                           src={preview.mainImage}
                           alt={preview.category}
-                          className="category-main-img mb-2"
+                          className="category-main-img mb-1"
                           style={{ objectFit: 'cover' }}
                         />
                       )}
-                      <div className="mt-auto d-flex justify-content-between gap-1">
+                      <div className="d-flex justify-content-between gap-1 mt-1">
                         {preview.images.map((img, idx) => (
                           <img
                             key={idx}


### PR DESCRIPTION
## Summary
- Only apply navbar color to featured category cards
- Reduce spacing between main and thumbnail images in category cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cd445aa6883209df0acda3795f74b