### PR TITLE
feat: refine featured category card layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -136,6 +136,11 @@ button:focus-visible {
   background-color: #FFC9C9;
 }
 
+.category-card .card-title {
+  font-size: 1.25rem;
+  color: #fff;
+}
+
 .category-main-img {
   width: 100%;
   height: 60%;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -331,8 +331,8 @@ export default function Home() {
                           style={{ objectFit: 'cover' }}
                         />
                       )}
-                      <div className="d-flex justify-content-between gap-1 mt-1">
-                        {preview.images.map((img, idx) => (
+                      <div className="d-flex justify-content-center gap-1 mt-1 mb-1">
+                        {preview.images.slice(0, 4).map((img, idx) => (
                           <img
                             key={idx}
                             src={img}


### PR DESCRIPTION
## Summary
- enlarge and recolor featured category card titles
- tighten spacing on preview thumbnails and enforce 4 items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cd8f22dc083209d91bfd7d745f95d