### PR TITLE
Reduce highlighted category card height

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -129,7 +129,7 @@ button:focus-visible {
 
 .category-card {
   width: 100%;
-  min-height: 260px;
+  min-height: 220px;
   border: none;
   border-radius: 0;
   box-shadow: none;
@@ -143,7 +143,7 @@ button:focus-visible {
 
 .category-main-img {
   width: 100%;
-  height: calc(60% - 10px);
+  height: calc(55% - 10px);
   margin-top: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Decrease minimum height for highlighted category cards and adjust main image proportion to make cards more compact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d7e25c1cc8320b8bf0e528559a806