### PR TITLE
Reduce highlighted category card height

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -129,7 +129,7 @@ button:focus-visible {
 
 .category-card {
   width: 100%;
-  min-height: 260px;
+  height: 220px;
   border: none;
   border-radius: 0;
   box-shadow: none;


### PR DESCRIPTION
## Summary
- Set a fixed height for highlighted category cards to shrink pink background area
- Restore main image proportion to its original size

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d7e25c1cc8320b8bf0e528559a806