### PR TITLE
fix: shrink category card background

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -143,7 +143,7 @@ button:focus-visible {
 
 .category-main-img {
   width: 100%;
-  height: calc(55% - 10px);
+  height: calc(60% - 10px);
   margin-top: 10px;
 }
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -320,8 +320,8 @@ export default function Home() {
             <div className="row g-3 justify-content-center">
               {categoryPreviews.map(preview => (
                 <div key={preview.category} className="col-12 col-md-4">
-                  <div className="card h-100 category-card text-center">
-                    <div className="card-body d-flex flex-column p-2 h-100">
+                  <div className="card category-card text-center">
+                    <div className="card-body d-flex flex-column p-2">
                       <h6 className="card-title mb-2">{preview.category}</h6>
                       {preview.mainImage && (
                         <img


### PR DESCRIPTION
## Summary
- restore category preview image height
- drop forced full-height classes so pink background shrinks with content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d898eae4483208fbd0c7b7808f1d0