### PR TITLE
Expand featured product listings

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -351,6 +351,76 @@ export default function Home() {
           </div>
         </div>
       )}
+      {featured.length > 6 && (
+        <div className="featured-section mt-5">
+          <div className="container">
+            <div className="row g-0 justify-content-center mb-4">
+              {Array.from({ length: 6 }).map((_, i) => {
+                const prod = featured[6 + i];
+                if (!prod) {
+                  return (
+                    <div key={i} className="col-6 col-md-2">
+                      <div className="card h-100 featured-card" />
+                    </div>
+                  );
+                }
+                const images = prod.images || [];
+                const img = images.length > 0 ? images[Math.floor(Math.random() * images.length)] : null;
+                return (
+                  <div key={prod._id} className="col-6 col-md-2">
+                    <div
+                      className="card h-100 featured-card text-center"
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => navigate(`/products/${prod._id}`)}
+                    >
+                      <div className="card-body d-flex flex-column align-items-center p-2">
+                        <h6 className="card-title mb-2">{prod.name}</h6>
+                        {img && (
+                          <img src={img} alt={prod.name} className="featured-img mb-2" style={{ objectFit: 'cover' }} />
+                        )}
+                        <p className="card-text mb-1">{prod.description}</p>
+                        <p className="card-text fw-bold mb-0">${prod.price}</p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="row g-0 justify-content-center">
+              {Array.from({ length: 6 }).map((_, i) => {
+                const prod = featured[12 + i];
+                if (!prod) {
+                  return (
+                    <div key={i} className="col-6 col-md-2">
+                      <div className="card h-100 featured-card" />
+                    </div>
+                  );
+                }
+                const images = prod.images || [];
+                const img = images.length > 0 ? images[Math.floor(Math.random() * images.length)] : null;
+                return (
+                  <div key={prod._id} className="col-6 col-md-2">
+                    <div
+                      className="card h-100 featured-card text-center"
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => navigate(`/products/${prod._id}`)}
+                    >
+                      <div className="card-body d-flex flex-column align-items-center p-2">
+                        <h6 className="card-title mb-2">{prod.name}</h6>
+                        {img && (
+                          <img src={img} alt={prod.name} className="featured-img mb-2" style={{ objectFit: 'cover' }} />
+                        )}
+                        <p className="card-text mb-1">{prod.description}</p>
+                        <p className="card-text fw-bold mb-0">${prod.price}</p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Keep original featured product grid to one row of six items
- Append two spaced rows of featured product cards beneath the category previews

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e090ef8bc8320898ce059d8f5cd13