### PR TITLE
Limit featured products to one row

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -242,7 +242,7 @@ export default function Home() {
       <div className="featured-section mt-4">
         <div className="container">
           <div className="row g-0 justify-content-center">
-            {Array.from({ length: 18 }).map((_, i) => {
+            {Array.from({ length: 6 }).map((_, i) => {
               const prod = featured[i];
               if (!prod) {
                 return (


### PR DESCRIPTION
## Summary
- reduce featured products grid from three rows to a single row of six cards

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e157a81e88320ba3a2b49653b48fe