### PR TITLE
feat: add featured category cards with custom background

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -133,12 +133,12 @@ button:focus-visible {
   border: none;
   border-radius: 0;
   box-shadow: none;
-  background-color: #FFC9C9;
+  background-color: #C9E4FF;
 }
 
 .category-card .card-title {
   font-size: 1.25rem;
-  color: #fff;
+  color: #333;
 }
 
 .category-main-img {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -327,6 +327,7 @@ export default function Home() {
         <>
           <div className="featured-section mt-4 mb-5">
             <div className="container">
+              <h4 className="text-center mb-3">Categorías destacadas</h4>
               <div className="row g-3 justify-content-center">
                 {categoryPreviews.map(preview => (
                   <div key={preview.category} className="col-12 col-md-4">


### PR DESCRIPTION
## Summary
- style category cards with a blue background and dark text
- label section as "Categorías destacadas" below perfume cards

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e29b05ee48320b467f301f76263c3