### PR TITLE
feat: color distinct category rows

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -139,7 +139,7 @@ button:focus-visible {
   border: none;
   border-radius: 0;
   box-shadow: none;
-  background-color: #C9E4FF;
+  background-color: var(--category-card-bg, #C9E4FF);
 }
 
 .category-card .card-title {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -10,6 +10,7 @@ export default function Home() {
   const [categoryProducts, setCategoryProducts] = useState([]);
   const [categoryPreviews, setCategoryPreviews] = useState([]);
   const [productsByCategory, setProductsByCategory] = useState({});
+  const rowColors = ['#C9E4FF', '#FFD6A5', '#CDEAC0', '#FFC8DD'];
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -123,35 +124,39 @@ export default function Home() {
 
   const renderCategoryCards = () => (
     <div className="row g-3 justify-content-center">
-      {categoryPreviews.map(preview => (
-        <div key={preview.category} className="col-12 col-md-4">
-          <div className="card category-card text-center">
-            <div className="card-body d-flex flex-column p-2">
-              <h6 className="card-title mb-2">{preview.category}</h6>
-              {preview.mainImage && (
-                <img
-                  src={preview.mainImage}
-                  alt={preview.category}
-                  className="category-main-img mb-1"
-                  style={{ objectFit: 'cover' }}
-                />
-              )}
-              <div className="d-flex justify-content-between gap-1 mt-1 mb-0">
-                {preview.images.slice(0, 4).map((img, idx) => (
+      {categoryPreviews.map((preview, index) => {
+        const rowIndex = Math.floor(index / 3);
+        const bgColor = rowColors[rowIndex % rowColors.length];
+        return (
+          <div key={preview.category} className="col-12 col-md-4">
+            <div className="card category-card text-center" style={{ '--category-card-bg': bgColor }}>
+              <div className="card-body d-flex flex-column p-2">
+                <h6 className="card-title mb-2">{preview.category}</h6>
+                {preview.mainImage && (
                   <img
-                    key={idx}
-                    src={img}
-                    alt={`${preview.category}-${idx}`}
-                    className="category-thumb"
-                    style={{ objectFit: 'cover', cursor: 'pointer' }}
-                    onClick={() => navigate(`/products?category=${encodeURIComponent(preview.category)}`)}
+                    src={preview.mainImage}
+                    alt={preview.category}
+                    className="category-main-img mb-1"
+                    style={{ objectFit: 'cover' }}
                   />
-                ))}
+                )}
+                <div className="d-flex justify-content-between gap-1 mt-1 mb-0">
+                  {preview.images.slice(0, 4).map((img, idx) => (
+                    <img
+                      key={idx}
+                      src={img}
+                      alt={`${preview.category}-${idx}`}
+                      className="category-thumb"
+                      style={{ objectFit: 'cover', cursor: 'pointer' }}
+                      onClick={() => navigate(`/products?category=${encodeURIComponent(preview.category)}`)}
+                    />
+                  ))}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 


### PR DESCRIPTION
## Summary
- cycle through preset colors so each category card row has consistent but unique background
- expose category card background via CSS variable for easy theming

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e31e183ac8320ac1516e9ac5a6855