### PR TITLE
feat: highlight second category row in yellow

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -10,7 +10,7 @@ export default function Home() {
   const [categoryProducts, setCategoryProducts] = useState([]);
   const [categoryPreviews, setCategoryPreviews] = useState([]);
   const [productsByCategory, setProductsByCategory] = useState({});
-  const rowColors = ['#C9E4FF', '#FFD6A5', '#CDEAC0', '#FFC8DD'];
+  const rowColors = ['#C9E4FF', '#FFFF00', '#CDEAC0', '#FFC8DD'];
   const navigate = useNavigate();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure second "Categorías destacadas" row uses a yellow card background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f43de077c832099db0e6c2edb0206