### PR TITLE
Cycle category card colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,7 @@ button:focus-visible {
   border-radius: 0;
   box-shadow: none;
   background-color: var(--category-card-bg, #C9E4FF);
+  transition: background-color 0.5s ease;
 }
 
 .category-card .card-title {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,6 +11,7 @@ export default function Home() {
   const [categoryPreviews, setCategoryPreviews] = useState([]);
   const [productsByCategory, setProductsByCategory] = useState({});
   const rowColors = ['#C9E4FF', '#FFFF00', '#CDEAC0', '#FFC8DD'];
+  const [colorIndex, setColorIndex] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -111,6 +112,13 @@ export default function Home() {
     return () => carouselElement.removeEventListener('slid.bs.carousel', updateOverlayColor);
   }, []);
 
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setColorIndex(prev => (prev + 1) % rowColors.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [rowColors.length]);
+
   const handleNext = () => {
     if (promos.length > 6) {
       setStartIndex((prev) => (prev + 6) % promos.length);
@@ -126,7 +134,7 @@ export default function Home() {
     <div className="row g-3 justify-content-center">
       {categoryPreviews.map((preview, index) => {
         const rowIndex = Math.floor(index / 3);
-        const bgColor = rowColors[rowIndex % rowColors.length];
+        const bgColor = rowColors[(rowIndex + colorIndex) % rowColors.length];
         return (
           <div key={preview.category} className="col-12 col-md-4">
             <div className="card category-card text-center" style={{ '--category-card-bg': bgColor }}>


### PR DESCRIPTION
## Summary
- Rotate background colors of featured category cards using a timed interval.
- Add smooth background-color transitions for category cards.

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`
- `npm test` (backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f45d053348320b7c6cea0b0cb4e07