### PR TITLE
feat: enable product reservations and stock ribbons

### DIFF
--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -4,6 +4,7 @@ const itemSchema = new mongoose.Schema({
   product: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', required: true },
   quantity: { type: Number, required: true },
   price: { type: Number, required: true },
+  reserved: { type: Boolean, default: false },
 });
 
 const orderSchema = new mongoose.Schema({

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -17,6 +17,7 @@ const productSchema = new mongoose.Schema({
   inStock: { type: Boolean, default: true },
   stock: { type: Number, default: 0 },
   featured: { type: Boolean, default: false },
+  allowReservation: { type: Boolean, default: false },
 }, {
   timestamps: true,
 });

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -13,10 +13,10 @@ router.post('/', protect, async (req, res) => {
     return res.status(400).json({ message: 'Sin items' });
   }
   try {
-    const populated = await Promise.all(items.map(async ({ product, quantity }) => {
+    const populated = await Promise.all(items.map(async ({ product, quantity, reserved }) => {
       const prod = await Product.findById(product);
       if (!prod) throw new Error('Producto no encontrado');
-      return { product: prod._id, quantity, price: prod.price };
+      return { product: prod._id, quantity, price: prod.price, reserved };
     }));
     const total = populated.reduce((sum, i) => sum + i.price * i.quantity, 0);
     const order = await Order.create({ user: req.user._id, items: populated, total });

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -53,9 +53,9 @@ router.get('/:id', async (req, res) => {
 
 // Crear un nuevo producto
 router.post('/', protect, isAdmin, async (req, res) => {
-  const { name, description, price, images = [], category, gender = 'unisex', inStock, stock } = req.body;
+  const { name, description, price, images = [], category, gender = 'unisex', inStock, stock, allowReservation } = req.body;
   if (images.length > 3) return res.status(400).json({ message: 'Máximo 3 imágenes' });
-  const product = new Product({ name, description, price, images, category, gender, inStock, stock });
+  const product = new Product({ name, description, price, images, category, gender, inStock, stock, allowReservation });
 
   try {
     const newProduct = await product.save();
@@ -103,7 +103,7 @@ router.put('/:id/featured', protect, isAdmin, async (req, res) => {
 
 // Actualizar un producto
 router.put('/:id', protect, isAdmin, async (req, res) => {
-  const { name, description, price, images = [], category, gender = 'unisex', inStock, stock } = req.body;
+  const { name, description, price, images = [], category, gender = 'unisex', inStock, stock, allowReservation } = req.body;
   if (images.length > 3) return res.status(400).json({ message: 'Máximo 3 imágenes' });
   try {
     const product = await Product.findById(req.params.id);
@@ -116,6 +116,7 @@ router.put('/:id', protect, isAdmin, async (req, res) => {
     product.gender = gender;
     product.inStock = inStock;
     if (stock !== undefined) product.stock = stock;
+    if (allowReservation !== undefined) product.allowReservation = allowReservation;
     const updated = await product.save();
     res.json(updated);
   } catch (err) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -163,4 +163,35 @@ button:focus-visible {
 .product-card {
   background-color: #fff;
   margin-bottom: 1rem;
+  position: relative;
+}
+
+.stock-ribbon {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 75px;
+  height: 75px;
+  overflow: hidden;
+}
+
+.stock-ribbon span {
+  position: absolute;
+  bottom: 6px;
+  right: -28px;
+  display: block;
+  width: 100px;
+  padding: 5px 0;
+  color: #fff;
+  text-align: center;
+  transform: rotate(-45deg);
+  font-size: 0.75rem;
+}
+
+.stock-ribbon.ribbon-green span {
+  background-color: #28a745;
+}
+
+.stock-ribbon.ribbon-red span {
+  background-color: #dc3545;
 }

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -12,7 +12,7 @@ export default function Cart() {
     const token = localStorage.getItem('token');
     try {
       await axios.post('http://localhost:5000/api/orders', {
-        items: items.map(i => ({ product: i.product._id, quantity: i.quantity }))
+        items: items.map(i => ({ product: i.product._id, quantity: i.quantity, reserved: i.reserved }))
       }, { headers: { Authorization: `Bearer ${token}` } });
       alert('Orden creada');
       clearCart();
@@ -47,7 +47,7 @@ export default function Cart() {
                 </div>
                 <div>
                   <span className="me-2">${item.product.price * item.quantity}</span>
-                  <button className="btn btn-sm btn-danger" onClick={() => removeItem(item.product._id, item.quantity)}>X</button>
+                  <button className="btn btn-sm btn-danger" onClick={() => removeItem(item.product._id, item.quantity, item.reserved)}>X</button>
                 </div>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- add allowReservation to products and order item flag
- show stock ribbons and reservation button on product cards
- support reserving out-of-stock items in cart and orders

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f49d0ffd48320970d37f6413b25fb