### PR TITLE
feat: allow reserving out of stock items

### DIFF
--- a/frontend/src/pages/AddProduct.jsx
+++ b/frontend/src/pages/AddProduct.jsx
@@ -14,6 +14,7 @@ export default function AddProduct() {
     gender: 'unisex',
     inStock: true,
     stock: 0,
+    allowReservation: false,
   });
   const navigate = useNavigate();
 
@@ -46,6 +47,7 @@ export default function AddProduct() {
         gender: form.gender,
         inStock: form.inStock,
         stock: Number(form.stock),
+        allowReservation: form.allowReservation,
       }, { headers: { Authorization: `Bearer ${token}` } });
       alert('Producto creado');
       navigate('/products');
@@ -105,6 +107,18 @@ export default function AddProduct() {
           <input className="form-check-input" type="checkbox" checked={form.inStock}
             onChange={(e) => setForm({ ...form, inStock: e.target.checked })} id="instock" />
           <label className="form-check-label" htmlFor="instock">En stock</label>
+        </div>
+        <div className="form-check mb-3">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="allowReserve"
+            checked={form.allowReservation}
+            onChange={(e) => setForm({ ...form, allowReservation: e.target.checked })}
+          />
+          <label className="form-check-label" htmlFor="allowReserve">
+            Permitir reservas sin stock
+          </label>
         </div>
         <button type="submit" className="btn btn-primary">Guardar</button>
       </form>

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -1,10 +1,14 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useState, useContext } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import CartContext from '../context/CartContext.jsx';
 
 export default function ProductDetail() {
   const { id } = useParams();
   const [product, setProduct] = useState(null);
+  const [qty, setQty] = useState(1);
+  const { addItem, reserveItem } = useContext(CartContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     axios.get(`http://localhost:5000/api/products/${id}`)
@@ -13,6 +17,37 @@ export default function ProductDetail() {
   }, [id]);
 
   if (!product) return <div className="container mt-5">Cargando...</div>;
+
+  const handleAdd = async () => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      alert('Debes iniciar sesión para agregar productos');
+      navigate('/login');
+      return;
+    }
+    const quantity = Number(qty);
+    if (quantity <= 0) return;
+    if (quantity > product.stock) {
+      alert('No hay suficiente stock');
+      return;
+    }
+    await addItem(product, quantity);
+    setProduct(p => ({ ...p, stock: p.stock - quantity }));
+    setQty(1);
+  };
+
+  const handleReserve = async () => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      alert('Debes iniciar sesión para reservar productos');
+      navigate('/login');
+      return;
+    }
+    const quantity = Number(qty);
+    if (quantity <= 0) return;
+    await reserveItem(product, quantity);
+    setQty(1);
+  };
 
   return (
     <div className="container mt-5">
@@ -25,6 +60,36 @@ export default function ProductDetail() {
           <img key={idx} src={img} alt={product.name} className="me-2 mb-2" style={{maxWidth:'200px'}} />
         ))}
       </div>
+      <div className="input-group mt-3 mb-2" style={{maxWidth:'120px'}}>
+        <input
+          type="number"
+          min="1"
+          className="form-control"
+          value={qty}
+          onChange={e => setQty(e.target.value)}
+        />
+      </div>
+      {product.stock > 0 ? (
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={!localStorage.getItem('token')}
+          onClick={handleAdd}
+        >
+          Agregar al carrito
+        </button>
+      ) : product.allowReservation ? (
+        <button
+          type="button"
+          className="btn btn-outline-primary"
+          disabled={!localStorage.getItem('token')}
+          onClick={handleReserve}
+        >
+          Reservar
+        </button>
+      ) : (
+        <button type="button" className="btn btn-secondary" disabled>Sin stock</button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow admins to mark products as reservable when out of stock during creation
- let users reserve out-of-stock items from the product detail page

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend)
- `npm test` (backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f4ef008b083209393b067020e6ba6