### PR TITLE
Warn users about reservation dispatch delay

### DIFF
--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -45,6 +45,10 @@ export default function ProductDetail() {
     }
     const quantity = Number(qty);
     if (quantity <= 0) return;
+    const confirmed = window.confirm(
+      'Advertencia: su producto puede tardar hasta 5 días hábiles en ser despachado. La empresa hará lo necesario para que le llegue lo antes posible. ¿Desea confirmar la reserva?'
+    );
+    if (!confirmed) return;
     await reserveItem(product, quantity);
     setQty(1);
   };

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -150,6 +150,10 @@ export default function Products() {
     }
     const qty = Number(quantities[prod._id] || 1);
     if (qty <= 0) return;
+    const confirmed = window.confirm(
+      'Advertencia: su producto puede tardar hasta 5 días hábiles en ser despachado. La empresa hará lo necesario para que le llegue lo antes posible. ¿Desea confirmar la reserva?'
+    );
+    if (!confirmed) return;
     await reserveItem(prod, qty);
     setQuantities(q => ({ ...q, [prod._id]: 1 }));
   };


### PR DESCRIPTION
## Summary
- prompt users to confirm reservation after warning of up to 5 business day dispatch delay in product detail
- display same reservation confirmation warning in product list

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f538d02e48320a3c31d99bd146e15