### PR TITLE
Clean up Mongo connection settings

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,3 +1,3 @@
-MONGO_URI=mongodb://localhost:27017/E-commers
+MONGO_URI=mongodb://127.0.0.1:27017/E-commers
 PORT=5000
 JWT_SECRET=5aa3ec7fd3b3d847f08141a3ba15d9a6f134e9a6580dbc970e2fd40938c5f75ebbc0b630e80e31de9e0012a040a50cd968f2dd3901bd0bc0ccc38ba471d6ce0f

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,10 +24,8 @@ app.get('/', (req, res) => {
   res.send('API Running');
 });
 
-mongoose.connect(process.env.MONGO_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-}).then(() => console.log('MongoDB connected'))
+mongoose.connect(process.env.MONGO_URI)
+  .then(() => console.log('MongoDB connected'))
   .catch(err => console.error(err));
 
 app.use('/api/users', authRoutes);


### PR DESCRIPTION
### Motivation
- Remove deprecated Mongoose connection options and avoid IPv6 `localhost` resolution that caused `ECONNREFUSED ::1:27017` errors when connecting to MongoDB.

### Description
- Simplified the MongoDB connection by removing the deprecated options from `backend/server.js` and relying on the driver defaults via `mongoose.connect(process.env.MONGO_URI)`.
- Updated the default `MONGO_URI` in `backend/.env` from `mongodb://localhost:27017/E-commers` to `mongodb://127.0.0.1:27017/E-commers` to force IPv4 and avoid `::1` resolution issues.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969a64ccc24832085117a2f5aecd1cf)